### PR TITLE
Bump to 1.0.4 (and tag)

### DIFF
--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -1,6 +1,6 @@
 {sys, [
        {lib_dirs, ["apps", "../deps"]},
-       {rel, "mover", "1.0.2",
+       {rel, "mover", "1.0.4",
         [
          kernel,
          stdlib,


### PR DESCRIPTION
Bump version to trigger new build and artifact version.
