### PR TITLE
add dry-run option to migrator

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -89,7 +89,10 @@ Vagrant::Config.run do |config|
         }
       },
       "mover" => { "dev_mode" => true },
-      "munin" => { "stub" => true }
+      "munin" => { "stub" => true },
+      "tags" => [
+        # "mover-dry-run" # don't orchestrate via redis
+      ]
     }
     chef.data_bags_path = "#{ENV['OPSCODE_PLATFORM_REPO']}/data_bags"
     chef.roles_path = "#{ENV['OPSCODE_PLATFORM_REPO']}/roles"

--- a/src/mover_org_migrator.erl
+++ b/src/mover_org_migrator.erl
@@ -41,18 +41,26 @@
                  org_name :: string(),   % name of the org being migrated
                  org_guid :: string(),   % guid of the org being migrated
                  start_time :: term(),   % timestamp indicating start of migration operation
-                 error :: term()         % the error that has placed us in failure state.
+                 error :: term(),        % the error that has placed us in failure state.
+                 dry_run :: boolean()    % whether to perform redis operations and switch org via load balancer
                }).
 
 start_link(Config) ->
     gen_fsm:start_link(?MODULE, Config, []).
 
-init(Config) ->
+init(OrgName) ->
     % TODO config is currently just org name, we may want to
     % factor up some of the account_info stuff out of moser.
-    OrgGuid = moser_utils:orgname_to_guid(Config),
-    {ok, disable_org_access, #state{org_name = Config, org_guid = OrgGuid, start_time = os:timestamp()}, 0}.
+    OrgGuid = moser_utils:orgname_to_guid(OrgName),
+    DryRun = envy:get(mover, dry_run, boolean),
+    {ok, disable_org_access, #state{org_name = OrgName,
+                                    org_guid = OrgGuid,
+                                    start_time = os:timestamp(),
+                                    dry_run = DryRun}, 0}.
 
+disable_org_access(timeout, #state{org_name = OrgName, dry_run = true} = State) ->
+    lager:info(?ORG_META(OrgName), "Dry Run - skipping maintenance mode", []),
+    {next_state, migrate_org, State, 0};
 disable_org_access(timeout, #state{org_name = OrgName} = State) ->
     lager:info(?ORG_META(OrgName), "Placing organization into maintenance mode", []),
     case mover_org_darklaunch:disable_org(OrgName) of
@@ -62,6 +70,7 @@ disable_org_access(timeout, #state{org_name = OrgName} = State) ->
             %lager:error(?ORG_META(OrgName), "Failed to place org into maintenance mode, skipping it: ~p", [Error]),
             {stop, {error, Error}, State}
     end.
+
 
 migrate_org(timeout, #state{org_name = OrgName} = State) ->
     lager:info(?ORG_META(OrgName), "Migrating organization data", []),
@@ -86,7 +95,9 @@ verify_org(timeout, #state{org_name = OrgName} = State) ->
             {next_state, abort_migration, #state{error = Error} = State, 0}
     end.
 
-
+set_org_to_sql(timeout, #state{org_name = OrgName, dry_run = true} = State) ->
+    lager:info(?ORG_META(OrgName), "Dry Run - Skipping switching org to sql", []),
+    {next_state, enable_org_access, State, 0};
 set_org_to_sql(timeout, #state{org_name = OrgName} = State) ->
     lager:info(?ORG_META(OrgName), "Setting organization to SQL mode", []),
     case mover_org_darklaunch:org_to_sql(OrgName, ?PHASE_2_MIGRATION_COMPONENTS) of
@@ -98,6 +109,9 @@ set_org_to_sql(timeout, #state{org_name = OrgName} = State) ->
             {next_state, abort_migration, #state{error = Error} = State, 0}
     end.
 
+enable_org_access(timeout, #state{org_name = OrgName, dry_run = true} = State) ->
+    lager:info(?ORG_META(OrgName), "Dry Run - skipping org enable", []),
+    {next_state, complete_migration, State, 0};
 enable_org_access(timeout, #state{org_name = OrgName} = State) ->
     lager:info(?ORG_META(OrgName), "Removing organization from maintenance mode, enabling access", []),
     case mover_org_darklaunch:enable_org(OrgName) of
@@ -142,6 +156,3 @@ terminate(_Reason, _StateName, _State) ->
 
 code_change(_OldVsn, StateName, State, _Extra) ->
     {ok, StateName, State}.
-
-
-

--- a/src/mover_org_migrator_sup.erl
+++ b/src/mover_org_migrator_sup.erl
@@ -3,13 +3,15 @@
 %% @author Marc Paradise <marc@opscode.com>
 %% @copyright 2011-2012 Opscode, Inc.
 
-% @doc a throwaway supervisor to allow for testing of mover_org_migrator 
+% @doc a throwaway supervisor to allow for testing of mover_org_migrator
 
--module(mover_org_migrator_sup). 
+-module(mover_org_migrator_sup).
 
 -behaviour(supervisor).
 
--export([init/1, start_link/0, start_org_migrator/1]).
+-export([init/1,
+         start_link/0,
+         start_org_migrator/1]).
 
 -define(SERVER, ?MODULE).
 start_link() ->
@@ -20,6 +22,5 @@ init([]) ->
                  temporary, 10000, worker, [mover_org_migrator]},
     {ok, {{simple_one_for_one, 10, 10}, [Spec]}}.
 
-start_org_migrator(OrgName) -> 
+start_org_migrator(OrgName) ->
     supervisor:start_child(?SERVER, [OrgName]).
-


### PR DESCRIPTION
The `dry_run` option to the org migrator will not connect to redis, allowing us to test the migration behavior under load in production and measure whether it effects other aspects of the running system.

Ping @seth @marcparadise 

@marcparadise This might create conflicts with your automation work that is in flight.
