### PR TITLE
mover dry-run from config

### DIFF
--- a/src/mover_org_darklaunch.erl
+++ b/src/mover_org_darklaunch.erl
@@ -32,9 +32,17 @@ org_to_sql(OrgName, Components) ->
     send_eredis_q(["HMSET", OrgKey] ++ PropKVs).
 
 send_eredis_q(Command) ->
+    %% if we're configured for- dry_run mode, don't send the commands to redis
+    send_eredis_q(envy:get(mover, dry_run, boolean), Command).
+
+send_eredis_q(true, _) ->
+	lager:info("Redis dry-run enabled"),
+    ok;
+send_eredis_q(false, Command) ->
     case eredis:q(mover_eredis_client, Command) of
         {ok, _} ->
             ok;
         {error, Error} ->
             {error, Error}
     end.
+


### PR DESCRIPTION
Instead of fixing all of the merge conflicts with the other branch, I went the route of moving the dry_run logic into the darklaunch module.

Ping @seth @marcparadise 
