### PR TITLE
opc migration

### DIFF
--- a/scripts/migrate
+++ b/scripts/migrate
@@ -1,0 +1,126 @@
+#!/usr/bin/env escript
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil;fill-column: 92 -*-
+%% %% ex: ts=4 sw=4 et ft=erlang
+%%! -hidden
+%%
+%% Copyright(c) 2013 Opscode, Inc
+%% All Rights Reserved
+%%
+%% @doc Migrate all orgs, one at a time, and output the summary results to stdout
+%% in the form:
+%%
+%% `
+%% Successfully Migrated: org-name-list
+%%     Failed to Migrate: org-name-list
+%%         Not Attempted: org-name-list
+%% '
+%%
+%% Output will be suppressed if the argument `silent' is provided to this script.
+%%
+%% Exit code is a bitmasked value as follows:
+%%
+%%   0 - migration completed with no errors or warnings
+%%   1 - aborted due to unexpected errors
+%%   2 - one or more orgs completed successfully
+%%   4 - one or more orgs failed to migrate
+%%   8 - one or more orgs could not be reset to a valid state, and
+%%       so no migration was attempted.
+%%
+%% Additionally, if these error codes occur they will not be bitmasked:
+%%   128 - invalid argument
+%%   256 - could not connect to mover node
+%%   512 - rpc request to mover node failed.
+%%  1024 - unknown error has occurred.
+%% <b>Important</b>: this must be run as root or connect will fail.
+
+
+-define(SELF, 'migrate-script@127.0.0.1').
+-define(MOVER, 'mover@127.0.0.1').
+-define(MOVER_COOKIE, 'mover').
+-define(MOVER_MOD, 'mover_batch_migrator').
+
+-define(ABORTED, 1).
+-define(ORGS_MIGRATED, 2).
+-define(ORGS_FAILED, 4).
+-define(ORGS_BAD_STATE, 8).
+-define(INVALID_ARGUMENT, 128).
+-define(MOVER_CONNECT_FAIL, 256).
+-define(MOVER_RPC_FAIL, 512).
+-define(UNKNOWN_ERROR, 1024).
+
+main([]) ->
+    main(normal);
+main(["silent"]) ->
+    main(silent);
+main(Other) when is_list(Other) ->
+    io:fwrite("Unknown argument(s): ~p.~nUsage: migrate [silent]~n", [Other]),
+    halt(?INVALID_ARGUMENT);
+main(NoiseLevel) when is_atom(NoiseLevel) ->
+    ExitCode = try
+        init_network(),
+        Results = migrate(),
+        parse_and_format(NoiseLevel, Results)
+    catch
+        error:Code when is_number(Code) ->
+            Code;
+        _:_ ->
+            ?UNKNOWN_ERROR
+    end,
+    halt(ExitCode).
+
+init_network() ->
+    net_kernel:start([?SELF]),
+    erlang:set_cookie(?MOVER, ?MOVER_COOKIE),
+    verify_ping(net_adm:ping(?MOVER), ?MOVER_CONNECT_FAIL),
+    R = try
+            rpc:call(?MOVER, ?MOVER_MOD, ping, [])
+        catch
+            _M:_R  ->
+               pang
+        end,
+    verify_ping(R, ?MOVER_RPC_FAIL).
+
+migrate() ->
+%[{status,complete},
+%       {successful_orgs,["org1"]},
+%       {failed_orgs,["org2"]},
+%       {reset_failed,["org3", "org4"]}].
+    rpc:call(?MOVER, ?MOVER_MOD, migrate_all, []).
+
+parse_and_format(NoiseLevel, Results) ->
+    C0 = status_to_response_code(proplists:get_value(status, Results)),
+    {C1, Success} = list_to_response_code(successful_orgs, Results, ?ORGS_MIGRATED),
+    {C2, Failed} = list_to_response_code(failed_orgs, Results, ?ORGS_FAILED),
+    {C3, ResetFail} = list_to_response_code(reset_failed, Results, ?ORGS_BAD_STATE),
+    write_org_list(NoiseLevel, "Successfully Migrated", Success),
+    write_org_list(NoiseLevel, "    Failed to Migrate", Failed),
+    write_org_list(NoiseLevel, "        Not Attempted", ResetFail),
+    C0 bor C1 bor C2 bor C3.
+
+status_to_response_code(complete) -> 0;
+status_to_response_code(aborted) -> 1.
+
+list_to_response_code(Key, Results, ResponseCode) ->
+    List = proplists:get_value(Key, Results),
+    Code = case length(List) of
+        0 -> 0;
+        _ -> ResponseCode
+    end,
+    {Code, List}.
+
+write_org_list(silent, _, _) -> ok;
+write_org_list(_, Subject, []) ->
+    io:fwrite("  ~s: none~n", [Subject]);
+write_org_list(_, Subject, Orgs) ->
+    io:fwrite("  ~s: ~s~n", [Subject, string:join(Orgs, ", ")]).
+
+
+verify_ping(pong, _HaltWith) -> ok;
+verify_ping(_Other, HaltWith) ->
+    % Doing a halt from here will not actual set exit code, presumably
+    % because trhere's additional program flow following this call.
+    % Throw an error instead.
+    error(HaltWith).
+
+
+

--- a/src/mover_batch_migrator.erl
+++ b/src/mover_batch_migrator.erl
@@ -1,0 +1,175 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil;fill-column: 92 -*-
+%% ex: ts=4 sw=4 et
+%% @author Marc A. Paradise <marc@opscode.com>
+%% @copyright 2013 Opscode, Inc.
+%%
+
+-module(mover_batch_migrator).
+
+-export([ping/0,
+         migrate_all/0]).
+
+-define(POLL_SLEEP_MS, 500).
+
+% Stolen from moser/src/moser.hrl
+-record(org_info,
+        { org_name = undefined,
+          org_id = undefined,
+          db_name = undefined,
+          is_precreated = false,
+          chef_ets,
+          auth_ets,
+          account_info = undefined,
+          start_time}).
+
+-compile([{parse_transform, lager_transform}]).
+
+ping() ->
+    pong.
+
+migrate_all() ->
+    % Disable sleep  - for OPC migrations, we are guaranteed no in-flight traffic.
+    application:set_env(mover, sleep_time, 0),
+
+    % Build dets tables
+    moser_acct_processor:process_account_file(),
+
+    % Migrate
+    R = proceed_migration(),
+
+    % Reply with results
+    process_results(R).
+
+proceed_migration() ->
+    proceed_migration(capture_org_state()).
+
+proceed_migration({ok, _}) ->
+    migrate();
+proceed_migration({error, Reason}) ->
+    {error, Reason, []}.
+
+migrate() ->
+    Orgs = org_list(),
+    migrate_next(Orgs, []).
+
+process_results({error, Reason, CompletedOrgs}) ->
+    [{status, {aborted, Reason}} | partition_results(CompletedOrgs)];
+process_results(CompletedOrgs) when is_list(CompletedOrgs) ->
+    [{status, complete} | partition_results(CompletedOrgs)].
+
+partition_results(Results) ->
+    {RF, MF, S} = lists:foldl(fun partition/2, {[],[],[]}, Results),
+    [{successful_orgs, S},
+     {failed_orgs, MF},
+     {reset_failed, RF}].
+
+partition({Org, migration_success}, {RF, MF, S}) ->
+    {RF, MF, [binary_to_list(Org) | S]};
+partition({Org, migration_failure}, {RF, MF, S}) ->
+    {RF, [binary_to_list(Org) | MF], S};
+partition({Org, {error, org_reset_failed}}, {RF, MF, S}) ->
+    {[binary_to_list(Org) | RF], MF, S}.
+
+org_list() ->
+    org_list(moser_state_tracker:unmigrated_orgs()).
+
+org_list(no_orgs_in_state) ->
+    [];
+org_list(OrgList) ->
+    OrgList.
+
+%% We'll migrate each org  individually so that we are
+%% able to reply with details for each org.
+migrate_next([], Acc) ->
+    Acc;
+migrate_next([Org|Rest], Acc) ->
+    lager:info([{org_name, Org}], "Requesting migration: ~p~n"),
+    case reset_org(Org) of
+        ok ->
+            do_migrate(Org, Rest, Acc);
+        Reason ->
+            migrate_next(Rest, [{Org, Reason} | Acc])
+    end.
+
+%% An org reset can fail for a number of valid reasons. When we are following the flow
+%% of interactively resetting multiple orgs then continuing, it makes sense to abort up front.
+%% However, in an unattended migration, we'll capture any error and just note that we can't reset the org,
+%% so that we can move on to the next org.
+reset_org(OrgName) ->
+    try
+        mover_util:reset_org(OrgName),
+        ok
+    catch
+        % Note that details are already captured in the error log - we'll
+        % continue processing so we can accumulate additional errors for
+        % analysis.
+        _Mod:_Reason ->
+            {error, org_reset_failed}
+    end.
+
+%% Kick off an org migration, and wait for it to finish
+do_migrate(Org, Remaining, Acc) ->
+    % Crash if mover manager fsm isn't in the expected state
+    {ok, burning_couches} = mover_manager:migrate_next(),
+    Status = wait_for_status(),
+    case proplists:get_value(fatal_stop, Status) of
+        true ->
+            % as with all errors, we will have captured error details in the log
+            {error, {migrations_halted, fatal_error}, Acc};
+        false ->
+            % A specific org may still fail, but that's not fatal - check for that results here.
+            Result = case lists:keysearch(orgs_failed, 1, Status) of
+                {value, {orgs_failed, 1}} ->
+                    {Org, migration_failure};
+                {value, {orgs_failed, 0}} ->
+                    {Org, migration_success}
+            end,
+            % In any case, capture the result and keep going.
+            migrate_next(Remaining, [Result | Acc])
+    end.
+
+
+
+%% poll mover_manager:status until it indicates that it's completed.
+wait_for_status() ->
+	{ok, Status} = mover_manager:status(),
+    case proplists:get_value(state, Status) of
+        ready ->
+            Status;
+        _ ->
+            timer:sleep(?POLL_SLEEP_MS),
+            wait_for_status()
+    end.
+
+%% Populate the org state table.  If it encounters an org that is
+%% already in the table, it will ignore it - any other error will cause it to abort
+%% insert operations
+%%
+%% This functionality used to be in moser_state_tracker but was removed
+%% in order to avoid any inadvertent possibility of rebuilding org state
+%% table after org creation was cut over to sql in production.
+capture_org_state() ->
+    Info = moser_acct_processor:open_account(),
+    AllOrgs = moser_acct_processor:all_orgs(Info),
+    case insert_orgs(AllOrgs, []) of
+       {error, Reason} ->
+           {error, Reason};
+       Result when is_list(Result) ->
+           {ok, Result}
+    end.
+
+insert_orgs([], Acc) ->
+    Acc;
+insert_orgs([#org_info{org_name = OrgName, org_id = OrgId} = Org | Rest], Acc) ->
+    case moser_state_tracker:insert_one_org(Org) of
+        ok ->
+            insert_orgs(Rest, [{OrgName, ok} | Acc]);
+        {error, {error, error, <<"23505">>, _Msg, _Detail}} ->
+            lager:warning([{org_name,OrgName}, {org_id, OrgId}], "org already exists, ignoring"),
+            insert_orgs(Rest, [{OrgName, duplicate} | Acc]);
+        {error, Reason} ->
+            lager:error([{org_name,OrgName}, {org_id, OrgId}],
+                        "stopping - failed to capture state because: ~p", [Reason]),
+            {error, {org_state_load_failed, Reason}}
+    end.
+

--- a/src/mover_org_darklaunch.erl
+++ b/src/mover_org_darklaunch.erl
@@ -43,7 +43,6 @@ send_eredis_q(Command) ->
     send_eredis_q(envy:get(mover, dry_run, boolean), Command).
 
 send_eredis_q(true, _) ->
-	lager:info("Redis dry-run enabled"),
     ok;
 send_eredis_q(false, Command) ->
     case eredis:q(mover_eredis_client, Command) of


### PR DESCRIPTION
- Add a self-contained module to perform single-pass migration of all orgs and provide per-org results in response. 
- add an escript that triggers this migration
- make it so that we don't start eredis at all if dry_run is true

ping @jkeiser 

/cc @seth @sdelano @manderson26 @hosh @oferrigni 
