### PR TITLE
add mover_manager:set_concurrency to allow concurrency to be changed during

### DIFF
--- a/src/mover_manager.erl
+++ b/src/mover_manager.erl
@@ -306,7 +306,7 @@ handle_sync_event({set_concurrency, Value}, _From, working, {max_worker_count = 
     {reply, {ok, no_change}, working, State};
 handle_sync_event({set_concurrency, Value}, _From, working, {max_worker_count = OldValue} = State) ->
     {reply, {ok, modified, OldValue}, working, State#state{max_worker_count = Value} };
-handle_sync_event(set_concurrency, _From, StateName, State) ->
+handle_sync_event({set_concurrency, _}, _From, StateName, State) ->
     {reply, {error, bad_state}, StateName, State};
 handle_sync_event(get_account_dets, _From, StateName, State = #state{ acct_info = AcctInfo }) ->
     {reply, AcctInfo, StateName, State};


### PR DESCRIPTION
Just a quick one-off change from an observed nice-to-have
ping @tylercloke @sdelano @manderson26 @o
