### PR TITLE
Refactored org_reset functions to use generic migration type.

### DIFF
--- a/README_FOR_ORGS.md
+++ b/README_FOR_ORGS.md
@@ -28,18 +28,18 @@ marked as ready for migration. The options below will do this, and will also
   delete any SQL records that exist for the org:
 
 ```
-mover_util:reset_org(OrgName).
+mover_util:reset_org(OrgName, *_migration_callback:migration_type()).
 
 ```
 * To prepare multiple orgs:
 
 ```
-mover_util:reset_orgs([Org1, Org2, ... OrgN]).
+mover_util:reset_orgs([Org1, Org2, ... OrgN], *_migration_callback:migration_type()).
 ```
 * To prepare orgs listed in a file (single line per org):
 
 ```
-mover_util:reset_orgs_from_file("/path/to/file").
+mover_util:reset_orgs_from_file("/path/to/file", *_migration_callback:migration_type()).
 ```
 * If you need to mark an org as ready for migration without deleting
   existing SQL records, you can do so as follows:

--- a/src/mover_util.erl
+++ b/src/mover_util.erl
@@ -10,8 +10,8 @@
 -module(mover_util).
 
 -export([populate_xdl_with_unmigrated_orgs/0,
-         reset_org/1,
-         reset_orgs/1,
+         reset_org/2,
+         reset_orgs/2,
          reset_orgs_from_file/1,
          call_if_exported/4]).
 
@@ -26,35 +26,37 @@ populate_xdl_with_unmigrated_orgs() ->
 %% @doc delete any SQL data for the named org and reset its state
 %% to indicate it's ready to migrate.
 %%
+reset_org(OrgName, MigrationType) ->
+    reset_org(OrgName, not_applicable, MigrationType).
 
-reset_org(OrgName) ->
-    reset_org(OrgName, not_applicable).
-
-reset_org(OrgName, Line) when is_list(OrgName) ->
-    reset_org(iolist_to_binary(OrgName), Line);
-reset_org(OrgName, Line) when is_binary(OrgName) ->
-    case moser_state_tracker:ready_migration(OrgName, mover_phase_1_migration_callback:migration_type()) of
+reset_org(OrgName, Line, MigrationType) when is_list(OrgName) ->
+    reset_org(iolist_to_binary(OrgName), Line, MigrationType);
+reset_org(OrgName, Line, MigrationType) when is_binary(OrgName) ->
+    case moser_state_tracker:ready_migration(OrgName, MigrationType) of
         ok ->
+	    % Check if GUID can be found from OrgName and log an error if it doesn't.
+	    % Vestigial code from when the GUID was actually needed but it doesn't hurt to
+	    % check this very rare error case still.
             Acct = moser_acct_processor:open_account(),
             case moser_acct_processor:get_org_guid_by_name(OrgName, Acct) of
                 not_found ->
-                    org_reset_error(OrgName, Line, "org does not exist in account table");
+                    org_reset_error(OrgName, Line, "org does not exist in account table", MigrationType);
                 _GUID ->
                     ok
             end;
         Other ->
-            org_reset_error(OrgName, Line, Other)
+            org_reset_error(OrgName, Line, Other, MigrationType)
     end.
 
-org_reset_error(OrgName, Line, Reason) ->
+org_reset_error(OrgName, Line, Reason, MigrationType) ->
     log_org_reset_error(OrgName, Line, Reason),
     % Advance state if possible, so that we can mark as failed.
-    ok = case moser_state_tracker:migration_started(OrgName, mover_phase_1_migration_callback:migration_type()) of
+    ok = case moser_state_tracker:migration_started(OrgName, MigrationType) of
         ok -> ok;
         {error, not_in_expected_state, _} -> ok;
         Error -> Error
     end,
-    ok = case moser_state_tracker:migration_failed(OrgName, reset_org, mover_phase_1_migration_callback:migration_type()) of
+    ok = case moser_state_tracker:migration_failed(OrgName, reset_org, MigrationType) of
         ok -> ok;
         {error, not_in_expected_state, State} ->
             log_org_reset_error(OrgName, Line, "Org state could not be set to failed."),
@@ -68,25 +70,25 @@ log_org_reset_error(OrgName, Line, Error) ->
     lager:error([{org_name, OrgName}], "Error on line ~p while resetting org: ~p", [Line, Error]).
 
 %% @doc Reset each org in the provided list of orgs.
-reset_orgs(Orgs) when is_list(Orgs) ->
-    [ reset_org(X) || X <- Orgs ].
+reset_orgs(Orgs) when is_list(Orgs, MigrationType) ->
+    [ reset_org(X, MigrationType) || X <- Orgs ].
 
 %% @doc Reset each org in the provided file, which must contain
 %% one org per line.
-reset_orgs_from_file(FileName) ->
+reset_orgs_from_file(FileName, MigrationType) ->
     {ok, Dev} = file:open(FileName, [read]),
-    process_lines(Dev, fun reset_org/2, 1).
+    process_lines(Dev, MigrationType, fun reset_org/2, 1).
 
-process_lines(Dev, Processor, LineNo) ->
+process_lines(Dev, MigrationType, Processor, LineNo) ->
     case io:get_line(Dev, "") of
         eof ->
             file:close(Dev),
             ok;
         "\n" ->
-            process_lines(Dev, Processor, LineNo + 1);
+            process_lines(Dev, MigrationType, Processor, LineNo + 1);
         Line ->
-            Processor(string:strip(Line, right, $\n), LineNo),
-            process_lines(Dev, Processor, LineNo + 1)
+            Processor(string:strip(Line, right, $\n), LineNo, MigrationType),
+            process_lines(Dev, MigrationType, Processor, LineNo + 1)
     end.
 
 call_if_exported(undefined, _FunName, Args, DefaultFun) ->


### PR DESCRIPTION
This was just something I noticed. Not needed for my revert branch. If we don't wanna add code flux we don't need to deal with this right now.
