### PR TITLE
Correct prep migration to NOT default to solr4

### DIFF
--- a/src/mover_reindex_dry_run_prep_migration_callback.erl
+++ b/src/mover_reindex_dry_run_prep_migration_callback.erl
@@ -66,4 +66,4 @@ reconfigure_object(_ObjectId, _AcctInfo) ->
     no_op.
 
 migration_complete() ->
-    mover_org_darklaunch:enable_solr4().
+    no_op.

--- a/test/mover_reindex_dry_run_prep_migration_callback_tests.erl
+++ b/test/mover_reindex_dry_run_prep_migration_callback_tests.erl
@@ -74,6 +74,5 @@ supervisor_should_be_transient_worker_sup() ->
 reconfigure_object_is_a_no_op() ->
     ?assertEqual(no_op, mover_reindex_dry_run_prep_migration_callback:reconfigure_object(org, acct)).
 
-migration_complete_should_default_to_solr4_and_enable_org_creation() ->
-    mock(mover_org_darklaunch, ?expect(enable_solr4, ?withArgs([]), ?andReturn(ignored))),
-    mover_reindex_dry_run_prep_migration_callback:migration_complete().
+migration_complete_is_a_no_op_because_this_is_dry_run() ->
+    ?assertEqual(no_op, mover_reindex_dry_run_prep_migration_callback:migration_complete()).


### PR DESCRIPTION
This fixes a copy pasta error found during a review.
