### PR TITLE
EC phase 2 migration and generalization

### DIFF
--- a/README_FOR_ORGS.md
+++ b/README_FOR_ORGS.md
@@ -28,18 +28,18 @@ marked as ready for migration. The options below will do this, and will also
   delete any SQL records that exist for the org:
 
 ```
-mover_util:reset_org(OrgName).
+mover_util:reset_org(OrgName, *_migration_callback:migration_type()).
 
 ```
 * To prepare multiple orgs:
 
 ```
-mover_util:reset_orgs([Org1, Org2, ... OrgN]).
+mover_util:reset_orgs([Org1, Org2, ... OrgN], *_migration_callback:migration_type()).
 ```
 * To prepare orgs listed in a file (single line per org):
 
 ```
-mover_util:reset_orgs_from_file("/path/to/file").
+mover_util:reset_orgs_from_file("/path/to/file", *_migration_callback:migration_type()).
 ```
 * If you need to mark an org as ready for migration without deleting
   existing SQL records, you can do so as follows:

--- a/scripts/migrate
+++ b/scripts/migrate
@@ -18,6 +18,15 @@
 %%         Not Attempted: org-name-list
 %% '
 %%
+%% Usage:
+%%  migrate:
+%%    will run with mover_phase_1_migration_callback and normal noise level
+%%  migrate silent:
+%%    will run with mover_phase_1_migration_callback and silent noise level
+%%  migrate <migration_callback> <noise_level>:
+%%    will run a migration on any valid <migration_callback> and noise level
+%%    where <noise_level> is "normal" or "silent"
+%%
 %% <b>Important</b>: this must be run as root or connect will fail.
 %% If an error occurs, it will also be displayed on the console.
 %% If any org encounters errors in migrating or resetting state,
@@ -35,16 +44,25 @@
 
 
 main([]) ->
-    main(normal);
+    main(mover_phase_1_migration_callback, normal);
 main(["silent"]) ->
-    main(silent);
-main(Other) when is_list(Other) ->
-    io:fwrite("Unknown argument(s): ~p.~nUsage: migrate [silent]~n", [Other]),
-    halt(?FAILURE_EXIT);
-main(NoiseLevel) when is_atom(NoiseLevel) ->
+    main(mover_phase_1_migration_callback, silent);
+main([Other]) ->
+    bad_noise_argument(Other);
+main([MigrationType, NoiseLevel]) ->
+    case NoiseLevel of
+        "silent" ->
+            main(list_to_atom(MigrationType), silent);
+        "normal" ->
+            main(list_to_atom(MigrationType), normal);
+        _ ->
+            bad_noise_argument(NoiseLevel)
+    end.
+
+main(MigrationType, NoiseLevel) ->
     {ExitCode, Message} = try
         init_network(),
-        Results = migrate(),
+        Results = migrate(MigrationType),
         parse_and_format(NoiseLevel, Results)
     catch
         error:{error, HaltWith} ->
@@ -56,6 +74,10 @@ main(NoiseLevel) when is_atom(NoiseLevel) ->
     end,
     io:fwrite("~n~s~n~n", [Message]),
     halt(ExitCode).
+
+bad_noise_argument(Argument) ->
+    io:fwrite("Unknown argument(s): ~p.~nUsage: migrate [silent] or migrate [migration_type] [silent|normal]~n", [Argument]),
+    halt(?FAILURE_EXIT).
 
 init_network() ->
     net_kernel:start([?SELF]),
@@ -69,12 +91,12 @@ init_network() ->
         end,
     verify_ping(R, "RPC to mover service failed").
 
-migrate() ->
+migrate(MigrationType) ->
 %[{status,complete},
 %       {successful_orgs,["org1"]},
 %       {failed_orgs,["org2"]},
 %       {reset_failed,["org3", "org4"]}].
-    rpc:call(?MOVER, ?MOVER_MOD, migrate_all, []).
+    rpc:call(?MOVER, ?MOVER_MOD, migrate_all, [MigrationType]).
 
 parse_and_format(NoiseLevel, Results) ->
     C0 = status_to_exit_code(proplists:get_value(status, Results)),

--- a/src/mover_batch_migrator.erl
+++ b/src/mover_batch_migrator.erl
@@ -35,7 +35,8 @@ migrate_all(CallbackMod) ->
     process_results(R).
 
 proceed_migration(CallbackMod) ->
-    proceed_migration(capture_org_state(CallbackMod), CallbackMod).
+    MigrationType = CallbackMod:migration_type(),
+    proceed_migration(capture_org_state(MigrationType), CallbackMod).
 
 proceed_migration({ok, _}, CallbackMod) ->
     migrate(CallbackMod);
@@ -117,8 +118,6 @@ do_migrate(Org, Remaining, Acc, CallbackMod) ->
             migrate_next(Remaining, [Result | Acc], CallbackMod)
     end.
 
-
-
 %% poll mover_manager:status until it indicates that it's completed.
 wait_for_status() ->
 	{ok, Status} = mover_manager:status(),
@@ -137,6 +136,6 @@ wait_for_status() ->
 %% This functionality used to be in moser_state_tracker but was removed
 %% in order to avoid any inadvertent possibility of rebuilding org state
 %% table after org creation was cut over to sql in production.
-capture_org_state(CallbackMod) ->
+capture_org_state(MigrationType) ->
     Info = mover_manager:get_account_dets(),
-    moser_state_tracker:capture_full_org_state_list(Info, CallbackMod).
+    moser_state_tracker:capture_full_org_state_list(Info, MigrationType).


### PR DESCRIPTION
Ping @opscode/server-team 

Use original migrate script for phase 2 and refactor things to be general.
- Write scripts/migrate to be able to accept arbitrary migration callbacks.
- Pull in PR related to `mover_util`, that removes hard coded references to `*phase_1*`
- Fix bug where `mover_batch_migrator` was passing the module name and not the migration name to `moser_state_tracker:capture_full_org_state_list`.
