### PR TITLE
Made refactors to accommodate non-org based migrations.

### DIFF
--- a/scripts/migrate
+++ b/scripts/migrate
@@ -3,7 +3,7 @@
 %% %% ex: ts=4 sw=4 et ft=erlang
 %%! -hidden
 %%
-%% Copyright(c) 2013 Opscode, Inc
+%% Copyright(c) 2014 Chef, Inc
 %% All Rights Reserved
 
 %% using compiled mode gives more informative error traces
@@ -21,11 +21,19 @@
 %% Usage:
 %%  migrate:
 %%    will run with mover_phase_1_migration_callback and normal noise level
+%%    with default ?MOVER_MOD migration processor
 %%  migrate silent:
 %%    will run with mover_phase_1_migration_callback and silent noise level
+%%    with default ?MOVER_MOD migration processor
 %%  migrate <migration_callback> <noise_level>:
 %%    will run a migration on any valid <migration_callback> and noise level
 %%    where <noise_level> is "normal" or "silent"
+%%    with default ?MOVER_MOD migration processor
+%%  migrate <migration_callback> <noise_level> <migration_processor>:
+%%    will run a migration on any valid <migration_callback> and noise level
+%%    where <noise_level> is "normal" or "silent", and <migration_processor>
+%%    is a valid migration processor (e.g. 'mover_batch_migrator' or
+%%    'mover_non_org_batch_migrator')
 %%
 %% <b>Important</b>: this must be run as root or connect will fail.
 %% If an error occurs, it will also be displayed on the console.
@@ -38,32 +46,41 @@
 -define(SELF, 'migrate-script@127.0.0.1').
 -define(MOVER, 'mover@127.0.0.1').
 -define(MOVER_COOKIE, 'mover').
--define(MOVER_MOD, 'mover_batch_migrator').
+-define(MOVER_MOD, "mover_batch_migrator").
 -define(SUCCESS_EXIT, 0).
 -define(FAILURE_EXIT, 1).
 
 
 main([]) ->
-    main(mover_phase_1_migration_callback, normal);
+    main(mover_phase_1_migration_callback, normal, ?MOVER_MOD);
 main(["silent"]) ->
-    main(mover_phase_1_migration_callback, silent);
+    main(mover_phase_1_migration_callback, silent, ?MOVER_MOD);
 main([Other]) ->
     bad_noise_argument(Other);
 main([MigrationType, NoiseLevel]) ->
+    main([MigrationType, NoiseLevel, ?MOVER_MOD]);
+main([MigrationType, NoiseLevel, MigrationProcessor]) ->
     case NoiseLevel of
         "silent" ->
-            main(list_to_atom(MigrationType), silent);
+            main(list_to_atom(MigrationType), silent, list_to_atom(MigrationProcessor));
         "normal" ->
-            main(list_to_atom(MigrationType), normal);
+            main(list_to_atom(MigrationType), normal, list_to_atom(MigrationProcessor));
         _ ->
             bad_noise_argument(NoiseLevel)
     end.
 
-main(MigrationType, NoiseLevel) ->
+main(MigrationType, NoiseLevel, MigrationProcessor) ->
     {ExitCode, Message} = try
-        init_network(),
-        Results = migrate(MigrationType),
-        parse_and_format(NoiseLevel, Results)
+        init_network(MigrationProcessor),
+        Results = migrate(MigrationType, MigrationProcessor),
+        % if successful_org is undefined in the results proplist
+        % then do a simple parse and format (likely transient queue migration).
+        case proplists:is_defined(successful_orgs, Results) of
+            false ->
+                simple_parse_and_format(Results);
+            _ ->
+                parse_and_format(NoiseLevel, Results)
+        end
     catch
         error:{error, HaltWith} ->
             {?FAILURE_EXIT, HaltWith};
@@ -79,24 +96,31 @@ bad_noise_argument(Argument) ->
     io:fwrite("Unknown argument(s): ~p.~nUsage: migrate [silent] or migrate [migration_type] [silent|normal]~n", [Argument]),
     halt(?FAILURE_EXIT).
 
-init_network() ->
+init_network(MigrationProcessor) ->
     net_kernel:start([?SELF]),
     erlang:set_cookie(?MOVER, ?MOVER_COOKIE),
     verify_ping(net_adm:ping(?MOVER), "Could not connect to mover service"),
     R = try
-            rpc:call(?MOVER, ?MOVER_MOD, ping, [])
+            rpc:call(?MOVER, MigrationProcessor, ping, [])
         catch
             _M:_R  ->
                pang
         end,
     verify_ping(R, "RPC to mover service failed").
 
-migrate(MigrationType) ->
+migrate(MigrationType, MigrationProcessor) ->
+% Orgs migrationc case:
 %[{status,complete},
 %       {successful_orgs,["org1"]},
 %       {failed_orgs,["org2"]},
 %       {reset_failed,["org3", "org4"]}].
-    rpc:call(?MOVER, ?MOVER_MOD, migrate_all, [MigrationType]).
+% Transient queue migration case:
+% [{status, complete}]
+    rpc:call(?MOVER, MigrationProcessor, migrate_all, [MigrationType]).
+
+simple_parse_and_format(Results) ->
+    Exit = status_to_exit_code(proplists:get_value(status, Results)),
+    {Exit, exit_code_message(Exit)}.
 
 parse_and_format(NoiseLevel, Results) ->
     C0 = status_to_exit_code(proplists:get_value(status, Results)),

--- a/scripts/migrate-to-bcrypt-users
+++ b/scripts/migrate-to-bcrypt-users
@@ -85,7 +85,7 @@ all_users_count() ->
       rpc:call(?MOVER, mover_user_hash_converter, all_users_count, []).
 
 sleep_until_migration_finished() ->
-    rpc:call(?MOVER, mover_batch_migrator, wait_for_status, []).
+    rpc:call(?MOVER, mover_util, wait_for_status, []).
 
 %% Reporting and exit status %%
 

--- a/src/mover_global_containers_migration_callback.erl
+++ b/src/mover_global_containers_migration_callback.erl
@@ -25,8 +25,8 @@ next_object() ->
     mover_transient_migration_queue:next(?MODULE).
 
 migration_action(Object, _AcctInfo) ->
-    {Guid, AuthzId, RequesterId, ContainerName, Data} = Object,
-    moser_global_object_converter:insert_container(Guid, AuthzId, RequesterId, ContainerName, Data).
+    {Guid, AuthzId, RequesterId, Data} = Object,
+    moser_global_object_converter:insert_container(Guid, AuthzId, RequesterId, Data).
 
 migration_type() ->
     <<"global_container_migration">>.

--- a/src/mover_transient_queue_batch_migrator.erl
+++ b/src/mover_transient_queue_batch_migrator.erl
@@ -1,0 +1,39 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil;fill-column: 92 -*-
+%% ex: ts=4 sw=4 et
+%% @author Tyler Cloke <tyler@getchef.com>
+%% @copyright 2013 Chef, Inc.
+%%
+%% A simpler version of mover_batch_migrator for transient queues
+
+-module(mover_transient_queue_batch_migrator).
+
+-export([
+	 ping/0,
+         migrate_all/1
+        ]).
+
+-include_lib("moser/include/moser.hrl").
+
+ping() ->
+    pong.
+
+migrate_all(CallbackMod) ->
+    % Disable sleep  - for OPC migrations, we are guaranteed no in-flight traffic.
+    application:set_env(mover, sleep_time, 0),
+
+    % Build dets tables
+    mover_manager:create_account_dets(),
+
+    run_migration().
+
+run_migration() ->
+    mover_manager:migrate(all, 20, mover_global_containers_migration_callback),
+    % wait for mover to be ready, and if the migration failed, return failed
+    Status = mover_util:wait_for_status(),
+    case proplists:get_value(fatal_stop, Status) of
+	true ->
+	    [{status, {aborted, fatal_error}}];
+	false ->
+	    [{status, complete}]
+    end.
+

--- a/src/mover_util.erl
+++ b/src/mover_util.erl
@@ -13,9 +13,24 @@
          reset_org/2,
          reset_orgs/2,
          reset_orgs_from_file/2,
-         call_if_exported/4]).
+         call_if_exported/4,
+         wait_for_status/0
+        ]).
 
 -include("mover.hrl").
+
+-define(POLL_SLEEP_MS, 500).
+
+%% @doc poll mover_manager:status until it indicates that it's completed.
+wait_for_status() ->
+	{ok, Status} = mover_manager:status(),
+    case proplists:get_value(state, Status) of
+        ready ->
+            Status;
+        _ ->
+            timer:sleep(?POLL_SLEEP_MS),
+            wait_for_status()
+    end.
 
 %% @doc Get a list of unmigrated orgs from migration_state_table
 %% and set the xdarklaunch flags


### PR DESCRIPTION
- Update migrate script to be able to take in non-default migration processor.
- Update migrate script to be able to handle non-org based migrations.
- Moved wait_for_status from mover_batch_migrator to mover_util.
- Added mover_transient_queue_batch_migrator to handle EC transient queue migrations.

Ping @opscode/server-team 
