### PR TITLE
Orgs migration plan.

### DIFF
--- a/docs/org_related_migrations.md
+++ b/docs/org_related_migrations.md
@@ -20,7 +20,7 @@
    + Start mover console via `/srv/chef_mover/current/bin$ sudo ./mover console`
 1. Put orgs in 503 mode:
    + DOWNTIME STARTS ON PUT, POST, DELETE ON ORGS / ASSOCS / INVITES AS SOON AS YOU RUN THE BELOW COMMAND!
-   + `knife ssh role:mysql-master '/opt/redis/bin/redis-cli HSET dl_default orgs_503_mode true'`
+   + Mover console: `mover_org_darklaunch:orgs_503_endpoint_mode("true").`
    + Verify that expected POST, PUT, DELETE requests return 503
 2. Now that there are no new org requests coming in, update the dets:
    + Mover console: `mover_manager:create_account_dets().`
@@ -36,14 +36,14 @@
 8. Run global_groups migration.
    + Mover console: `mover_manager:migrate(all, 20, mover_global_groups_migration_callback).`
 9. If all has gone well, flip API over to SQL:
-   + `knife ssh role:mysql-master '/opt/redis/bin/redis-cli HMSET dl_default couchdb_association_requests false couchdb_organizations false couchdb_associations false'`
+   + Mover console: `mover_org_darklaunch:org_related_endpoints_to_couch("false").`
 10. Turn orgs 503 mode off.
-    + `knife ssh role:mysql-master '/opt/redis/bin/redis-cli HSET dl_default orgs_503_mode false'`
+    + Mover console: `mover_org_darklaunch:orgs_503_endpoint_mode("false").`
 
 ### Resolution
 + Make sure there are no 500s and requests coming into erchef for org related endpoints.
 + If all goes to hell, run command to flip orgs back to couch:
-  + `knife ssh role:mysql-master '/opt/redis/bin/redis-cli HMSET dl_default couchdb_association_requests true couchdb_organizations true couchdb_associations true'`
+  + Mover console: `mover_org_darklaunch:org_related_endpoints_to_couch("true").`
 
 ### Misc
 

--- a/src/mover_org_darklaunch.erl
+++ b/src/mover_org_darklaunch.erl
@@ -19,7 +19,10 @@
          enable_solr4/0,
          enable_solr4/1,
          enable_both_solrs/1,
-         enable_solr1/1]).
+         enable_solr1/1,
+         orgs_503_endpoint_mode/1,
+         org_related_endpoints_to_couch/1
+]).
 
 disable_org_creation() ->
     send_eredis_q(["HMSET", "dl_org__OC_INTERNAL_NO_ORG", "disable_new_orgs", "true"]).
@@ -52,6 +55,17 @@ org_to_sql(OrgName, Components) ->
 
 enable_solr4() ->
     send_eredis_q(["HSET", "dl_default", "solr4", "true"]).
+
+%% input should be "true" or false"
+%% Note, only used in Hosted Chef.
+orgs_503_endpoint_mode(Key) ->
+    send_eredis_q(["HSET", "dl_default", "orgs_503_mode", Key]).
+
+%% input should be "true" or false"
+org_related_endpoints_to_couch(Key) ->
+    send_eredis_q(["HSET", "dl_default", "couchdb_organizations", Key]),
+    send_eredis_q(["HSET", "dl_default", "couchdb_associations", Key]),
+    send_eredis_q(["HSET", "dl_default", "couchdb_association_requests", Key]).
 
 %% Enables solr4 and disables the paired sending to solr1.4 and solr4.
 enable_solr4(OrgName) ->


### PR DESCRIPTION
Ping @opscode/server-team 

Needs darklaunch work from [here](https://chef.leankit.com/Boards/View/87539983/119158982) to finish up, but eyes are welcome.

Merge this [PR](https://github.com/opscode/opscode-platform-cookbooks/pull/592) first because its outcome affects this plan.
- [x] Cut a new release to pull in moser code and ship to opscode-omnibus.
