### PR TITLE
mover_manager: always reset 0 timeout when calling status

### DIFF
--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -1,5 +1,5 @@
 {sys,[{lib_dirs,["apps","../deps","../deps/oc_erchef/apps"]},
-      {rel,"mover","2.2.19",
+      {rel,"mover","2.2.20",
            [kernel,stdlib,sasl,crypto,folsom,stats_hero,moser,mover,
             chef_reindex]},
       {rel,"start_clean",[],[kernel,stdlib]},

--- a/src/mover_manager.erl
+++ b/src/mover_manager.erl
@@ -325,17 +325,14 @@ handle_sync_event(status, _From, StateName, #state{live_worker_count = LW,
                {objects_in_progress, LW},
                {objects_failed, EC},
                {fatal_stop, FS}],
-    case StateName of
-        % Fixed a race condition that prevents the gen_fsm from transitioning
-        % from the halting state to the ready state when looping over status.
-        %
-        % The zero timeout prevents a status call from clearing the gen_fsm timeout,
-        % and the halting -> ready transition is dependant on a timeout to occur.
-        halting ->
-            {reply, {ok, Summary}, StateName, State, 0};
-        _ ->
-            {reply, {ok, Summary}, StateName, State}
-    end;
+
+    %% Fixed a race condition that prevents the gen_fsm from transitioning
+    %% from the current state to the next state when looping over status.
+    %%
+    %% The zero timeout prevents a status call from clearing the gen_fsm timeout,
+    %% and the state transition is dependant on a timeout to occur.
+    {reply, {ok, Summary}, StateName, State, 0};
+
 handle_sync_event({set_concurrency, Value}, _From, working, #state{max_worker_count = Value} = State) ->
     {reply, {ok, no_change}, working, State};
 handle_sync_event({set_concurrency, Value}, _From, working, #state{max_worker_count = OldValue} = State) ->

--- a/src/mover_manager.erl
+++ b/src/mover_manager.erl
@@ -242,7 +242,7 @@ working(timeout, #state {max_worker_count = MW,
             start_worker(Object, State)
     end.
 
-working({start, _, _, _, _}, _From, State) ->
+working({start, _, _, _}, _From, State) ->
     {reply, {error, busy_now}, halting, State}.
 
 
@@ -273,7 +273,7 @@ halting(timeout, #state{} = State) ->
     %% Workers remainin, we stay 'halting' until there are none.
     {next_state, halting, State}.
 
-halting({start, _, _, _, _}, _From, State) ->
+halting({start, _, _, _}, _From, State) ->
     {reply, {error, halting_operations}, halting, State}.
 
 handle_info({'DOWN', _MRef, process, _Pid, Reason}, StateName,

--- a/src/mover_util.erl
+++ b/src/mover_util.erl
@@ -25,21 +25,13 @@
 %% In the case that things get stuck halting, it will try 240 more times
 %% (two minutes at current sleep time).
 wait_for_status() ->
-    wait_for_status(240).
-wait_for_status(HaltingRetries) when HaltingRetries == 0 ->
-    {ok, Status} = mover_manager:status(),
-    Status;
-wait_for_status(HaltingRetries) ->
     {ok, Status} = mover_manager:status(),
     case proplists:get_value(state, Status) of
         ready ->
             Status;
-        halting ->
-            timer:sleep(?POLL_SLEEP_MS),
-            wait_for_status(HaltingRetries - 1);
         _ ->
             timer:sleep(?POLL_SLEEP_MS),
-            wait_for_status(HaltingRetries)
+            wait_for_status()
     end.
 
 %% @doc Get a list of unmigrated orgs from migration_state_table


### PR DESCRIPTION
Because of the way we're triggering state transitions within the
mover_manager gen_fsm (via 0ms timeouts), calling mover_manager:status
has shown the ability to prevent a state transiation and cause
migrations to hang. This commit ALWAYS resets the gen_fsm timeout
value to 0 when calling mover_manager:status, so that we no longer
run into this situation.