### PR TITLE
Policyfile containers migrations

### DIFF
--- a/src/mover_batch_migrator.erl
+++ b/src/mover_batch_migrator.erl
@@ -26,7 +26,7 @@ migrate_all(CallbackMod) ->
     application:set_env(mover, sleep_time, 0),
 
     % Build dets tables
-    mover_manager:create_account_dets(),
+    mover_manager:create_account_dets(CallbackMod),
 
     % Migrate
     R = proceed_migration(CallbackMod),

--- a/src/mover_manager.erl
+++ b/src/mover_manager.erl
@@ -210,8 +210,9 @@ ready({start, NumObjects, NumWorkers, Worker}, _From, CurrentState) ->
                    worker = #migration_worker{callback_module = CallbackMod } = Worker},
     call_if_exported(CallbackMod, migration_init, [], fun no_op/0),
     {reply, {ok, burning_couches}, working, State, 0};
-ready(create_account_dets, _From, State = #state{ acct_info = Acct} ) ->
-    NewAccount = create_dets_files(Acct),
+ready(create_account_dets, _From, State = #state{ acct_info = _Acct} ) ->
+    %%NewAccount = create_dets_files(Acct),
+    NewAccount = couchdb_is_dead_yo,
     {reply, NewAccount, ready, State#state{acct_info = NewAccount}}.
 
 working(timeout, #state{objects_remaining = 0} = State) ->

--- a/src/mover_org_migration_callback.erl
+++ b/src/mover_org_migration_callback.erl
@@ -12,6 +12,7 @@
 	 migration_start_worker_args/2,
 	 migration_action/2,
 	 migration_type/0,
+     needs_account_dets/0,
 	 supervisor/0,
 	 error_halts_migration/0,
 	 reconfigure_object/2,
@@ -38,6 +39,9 @@ migration_action(OrgName, AcctInfo) ->
 			[OrgName, Exception, Reason, erlang:get_stacktrace()]),
             ok
     end.
+
+needs_account_dets() ->
+    true.
 
 migration_type() ->
     <<"org_migration">>.

--- a/src/mover_org_migration_callback.erl
+++ b/src/mover_org_migration_callback.erl
@@ -8,15 +8,15 @@
 -include_lib("moser/include/moser.hrl").
 
 -export([
-	 migration_init/0,
-	 migration_start_worker_args/2,
-	 migration_action/2,
-	 migration_type/0,
-     needs_account_dets/0,
-	 supervisor/0,
-	 error_halts_migration/0,
-	 reconfigure_object/2,
-	 next_object/0
+         migration_init/0,
+         migration_start_worker_args/2,
+         migration_action/2,
+         migration_type/0,
+         needs_account_dets/0,
+         supervisor/0,
+         error_halts_migration/0,
+         reconfigure_object/2,
+         next_object/0
 	 ]).
 
 migration_init() ->

--- a/src/mover_org_user_association_migration_callback.erl
+++ b/src/mover_org_user_association_migration_callback.erl
@@ -26,7 +26,7 @@ migration_init() ->
 migration_start_worker_args(Object, AcctInfo) ->
     [Object, AcctInfo].
 
-migration_action(Object, AcctInfo) ->
+migration_action(Object, _AcctInfo) ->
     {UserGuid, OrgGuid, LastUpdatedBy, UserBody} = Object,
     try
         moser_org_converter:insert_org_user_association(UserGuid, OrgGuid, LastUpdatedBy, UserBody)

--- a/src/mover_org_user_invites_migration_callback.erl
+++ b/src/mover_org_user_invites_migration_callback.erl
@@ -26,7 +26,7 @@ migration_init() ->
 migration_start_worker_args(Object, AcctInfo) ->
     [Object, AcctInfo].
 
-migration_action(Object, AcctInfo) ->
+migration_action(Object, _AcctInfo) ->
     {UserGuid, OrgGuid, LastUpdatedBy, UserBody} = Object,
     try
 	moser_org_converter:insert_org_user_invite(UserGuid, OrgGuid, LastUpdatedBy, UserBody)

--- a/src/mover_phase_1_migration_callback.erl
+++ b/src/mover_phase_1_migration_callback.erl
@@ -4,6 +4,7 @@
          migration_start_worker_args/2,
          migration_action/2,
          migration_type/0,
+         needs_account_dets/0,
          supervisor/0,
          error_halts_migration/0,
          reconfigure_object/2
@@ -20,6 +21,9 @@ migration_action(OrgName, AcctInfo) ->
 
 migration_type() ->
     <<"phase_1_migration">>.
+
+needs_account_dets() ->
+    true.
 
 supervisor() ->
     mover_org_migrator_sup.

--- a/src/mover_phase_2_migration_callback.erl
+++ b/src/mover_phase_2_migration_callback.erl
@@ -4,6 +4,7 @@
          migration_start_worker_args/2,
          migration_action/2,
          migration_type/0,
+         needs_account_dets/0,
          supervisor/0,
          error_halts_migration/0,
          reconfigure_object/2
@@ -25,6 +26,9 @@ migration_action(OrgName, AcctInfo) ->
 
 migration_type() ->
     <<"phase_2_migration">>.
+
+needs_account_dets() ->
+    true.
 
 supervisor() ->
     mover_org_migrator_sup.

--- a/src/mover_phase_2_prep_migration_callback.erl
+++ b/src/mover_phase_2_prep_migration_callback.erl
@@ -3,6 +3,7 @@
 -export([
 	  migration_init/0,
          migration_type/0,
+         needs_account_dets/0,
          supervisor/0,
          migration_start_worker_args/2,
          error_halts_migration/0,
@@ -54,6 +55,9 @@ next_object() ->
 
 migration_type() ->
     <<"phase_2_migration_prep">>.
+
+needs_account_dets() ->
+    true.
 
 supervisor() ->
     mover_transient_worker_sup.

--- a/src/mover_policies_containers_creation_callback.erl
+++ b/src/mover_policies_containers_creation_callback.erl
@@ -2,6 +2,7 @@
 
 -export([
 	 migration_init/0,
+	 migration_complete/0,
 	 migration_type/0,
 	 supervisor/0,
 	 migration_start_worker_args/2,
@@ -80,6 +81,9 @@ migration_init() ->
     {ok, OrgsToMigrateResults} = sqerl:execute(FindOrgsWithNoPoliciesContainer),
     OrgsToMigrate = [ db_results_to_org(OrgDbRow, Superuser) || OrgDbRow <- OrgsToMigrateResults],
     mover_transient_migration_queue:initialize_queue(?MODULE, OrgsToMigrate).
+
+migration_complete() ->
+    mv_oc_chef_authz_http:delete_pool().
 
 db_results_to_requestor(FieldsValues) ->
     {<<"username">>, Name} = proplists:lookup(<<"username">>, FieldsValues),

--- a/src/mover_policies_containers_creation_callback.erl
+++ b/src/mover_policies_containers_creation_callback.erl
@@ -64,10 +64,6 @@
         ]).
 
 migration_init() ->
-    %% TODO: remove this when testing is complete:
-    Nuke = <<"delete from containers where name in ('policies', 'policy_groups', 'cookbook_artifacts');">>,
-    sqerl:execute(Nuke),
-
     %% TODO: this fails if the pool is already created. Should be tolerant of
     %% errors and also should tear this down after the migration
     mv_oc_chef_authz_http:create_pool(),

--- a/src/mover_policies_containers_creation_callback.erl
+++ b/src/mover_policies_containers_creation_callback.erl
@@ -1,0 +1,434 @@
+-module(mover_policies_containers_creation_callback).
+
+-export([
+	 migration_init/0,
+	 migration_type/0,
+	 supervisor/0,
+	 migration_start_worker_args/2,
+	 error_halts_migration/0,
+	 reconfigure_object/2,
+	 migration_action/2,
+	 next_object/0
+	]).
+
+-include("mover.hrl").
+
+-record(mover_org, {id, authz_id, name, superuser}).
+-record(mover_requestor, {id, authz_id, username}).
+
+%% This is an ACE in human readable form
+-record(mover_hr_ace, {clients = [],
+                 users = [],
+                 groups = []}).
+
+%% NOTE: This record is copied from oc_erchef's oc_authz.hrl
+-record(authz_ace,  {actors = [], groups = []}).
+
+-record(mover_chef_container, {
+          id,
+          authz_id,
+          org_id,
+          name,
+          last_updated_by,
+          created_at,
+          updated_at
+         }).
+
+-define(ORG_POLICY_FOR_POLICIES_CONTAINERS,
+        [{create_containers, [policies, policy_groups, cookbook_artifacts]},
+
+         {acls,
+          [
+           %% Creator (superuser normally) goes everywhere
+           {add_acl, [{container, policies}],           [create, read, update, delete, grant], [{user, creator}]},
+           {add_acl, [{container, policy_groups}],      [create, read, update, delete, grant], [{user, creator}]},
+           {add_acl, [{container, cookbook_artifacts}], [create, read, update, delete, grant], [{user, creator}]},
+
+           %% Admins
+           {add_acl, [{container, policies}],           [create, read, update, delete, grant], [{group, users}]},
+           {add_acl, [{container, policy_groups}],      [create, read, update, delete, grant], [{group, users}]},
+           {add_acl, [{container, cookbook_artifacts}], [create, read, update, delete, grant], [{group, users}]},
+
+
+           %% users
+           {add_acl, [{container, policies}],           [create, read, update, delete], [{group, users}]},
+           {add_acl, [{container, policy_groups}],      [create, read, update, delete], [{group, users}]},
+           {add_acl, [{container, cookbook_artifacts}], [create, read, update, delete], [{group, users}]},
+
+           %% clients
+
+           {add_acl, [{container, policies}],           [read], [{group, clients}]},
+           {add_acl, [{container, policy_groups}],      [read], [{group, clients}]},
+           {add_acl, [{container, cookbook_artifacts}], [read], [{group, clients}]}
+          ]
+         }
+        ]).
+
+migration_init() ->
+    %% TODO: remove this when testing is complete:
+    Nuke = <<"delete from containers where name in ('policies', 'policy_groups', 'cookbook_artifacts');">>,
+    sqerl:execute(Nuke),
+
+    %% TODO: this fails if the pool is already created. Should be tolerant of
+    %% errors and also should tear this down after the migration
+    oc_chef_authz_http:create_pool(),
+    %% TODO: superuser name is somewhat configurable, it's set in oc_erchef's sys.config
+    {ok, SuperuserResults} = sqerl:adhoc_select([username, id, authz_id], users, {username, equals, <<"pivotal">>}),
+    Superuser = db_results_to_requestor(hd(SuperuserResults)),
+
+    %% Should do this for each container type and uniq the orgs just in case a migration partially bombs (?)
+    FindOrgsWithNoPoliciesContainer = <<"SELECT orgs.name, orgs.id, orgs.authz_id FROM orgs "
+                                        "LEFT JOIN containers ON orgs.id = org_id AND containers.name='policies' "
+                                        "WHERE containers.name IS NULL;">>,
+    {ok, OrgsToMigrateResults} = sqerl:execute(FindOrgsWithNoPoliciesContainer),
+    OrgsToMigrate = [ db_results_to_org(OrgDbRow, Superuser) || OrgDbRow <- OrgsToMigrateResults],
+    mover_transient_migration_queue:initialize_queue(?MODULE, OrgsToMigrate).
+
+db_results_to_requestor(FieldsValues) ->
+    {<<"username">>, Name} = proplists:lookup(<<"username">>, FieldsValues),
+    {<<"id">>,  Id}        = proplists:lookup(<<"id">>, FieldsValues),
+    {<<"authz_id">>,  AzId} = proplists:lookup(<<"authz_id">>, FieldsValues),
+    #mover_requestor{username = Name, id = Id, authz_id = AzId}.
+
+db_results_to_org(FieldsValues, Superuser) ->
+    %% Each object will be a list like this:
+    %% [{<<"name">>,<<"ponyville">>},
+    %%  {<<"id">>,<<"1e9ed26e6cbcdeedb128e896aa0f34c2">>},
+    %%  {<<"authz_id">>,<<"8184b014cba9484eabafb8568d299e67">>}
+    {<<"name">>, Name}     = proplists:lookup(<<"name">>, FieldsValues),
+    {<<"id">>,  Id}        = proplists:lookup(<<"id">>, FieldsValues),
+    {<<"authz_id">>, AzId} = proplists:lookup(<<"authz_id">>, FieldsValues),
+    #mover_org{name = Name, id = Id, authz_id = AzId, superuser = Superuser}.
+
+migration_start_worker_args(Object, AcctInfo) ->
+    [Object, AcctInfo].
+
+next_object() ->
+    mover_transient_migration_queue:next(?MODULE).
+
+migration_action(Org, _AcctInfo) ->
+    try
+        upgrade_org(Org)
+    catch
+        exit:Wat ->
+            oc_chef_authz_http:delete_pool(),
+            io:fwrite("Error: ~p~n", [Wat]),
+            io:fwrite("~p~n", [erlang:get_stacktrace()]),
+            {exit, Wat};
+        throw:Wat ->
+            oc_chef_authz_http:delete_pool(),
+            io:fwrite("Error: ~p~n", [Wat]),
+            io:fwrite("~p~n", [erlang:get_stacktrace()]),
+            {throw, Wat};
+        error:Wat ->
+            oc_chef_authz_http:delete_pool(),
+            io:fwrite("Error: ~p~n", [Wat]),
+            io:fwrite("~p~n", [erlang:get_stacktrace()]),
+            {error, Wat}
+    end.
+
+migration_type() ->
+    <<"policies_containers_creation">>.
+
+supervisor() ->
+    mover_transient_worker_sup.
+
+error_halts_migration() ->
+    true.
+
+reconfigure_object(_ObjectId, _AcctInfo) ->
+    no_op.
+
+insert_container_sql() ->
+      <<"INSERT INTO containers (id, authz_id, org_id, name,"
+        " last_updated_by, created_at, updated_at) VALUES"
+        " ($1, $2, $3, $4, $5, $6, $7)">>.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% VENDORED oc_chef_auth_org_creator CODE
+%%
+%% Code in here is vendored and then modified to remove external dependencies.
+%% This makes the data migration resilent to future code changes that might
+%% break the migration.
+%%
+%% TODO: remove use of these:
+%% * oc_chef_authz (maybe?)
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+upgrade_org(#mover_org{superuser = CreatingUser} = Org) ->
+    Cache = init_cache(Org, CreatingUser),
+    CacheWithGroups = prepopulate_groups(Cache, Org),
+    process_policy(?ORG_POLICY_FOR_POLICIES_CONTAINERS, Org, CreatingUser, CacheWithGroups).
+
+prepopulate_groups(Cache, #mover_org{id = OrgID}) ->
+    Cache1 = prepopulate_group(Cache, OrgID, admins),
+    Cache2 = prepopulate_group(Cache1, OrgID, users),
+    Cache3 = prepopulate_group(Cache2, OrgID, clients),
+    Cache3.
+
+prepopulate_group(Cache, OrgId, Group) ->
+    {ok, Results} = sqerl:adhoc_select([name, authz_id, org_id],
+                                       groups,
+                                       {'and', [{name, equals, Group}, {org_id, equals, OrgId}]}),
+    GroupFieldsList = hd(Results),
+    {<<"authz_id">>, AuthzId} = proplists:lookup(<<"authz_id">>, GroupFieldsList),
+    add_cache(Cache,{group, Group}, AuthzId).
+
+%%
+%% Execute a policy to create an org
+%%
+
+
+process_policy([], _, _, _Cache) ->
+    %% This is where we might extract some stuff from cache to descibe the created org
+    ok;
+process_policy([PolicyEntry|Policy], Org, User, Cache) ->
+    case process_policy_step(PolicyEntry, Org, User, Cache) of
+        {error, _} = Error -> Error;
+        {Cache1, Steps} ->
+            process_policy(Steps++Policy, Org, User, Cache1)
+    end.
+
+%% Returns a tuple of updated cache, and expanded steps to process
+%%
+process_policy_step({create_containers, List},
+                    #mover_org{id=OrgId}, #mover_requestor{authz_id=RequestorId}, Cache) ->
+    {create_object(OrgId, RequestorId, container, List, Cache), []};
+process_policy_step({set_acl_expanded, Object, Acl},
+                    #mover_org{}, #mover_requestor{authz_id=_RequestorId}, Cache) ->
+    {ResourceType, AuthzId} = find(Object, Cache),
+    Acl1 = [{Action, ace_to_authz(Cache, ACE)} || {Action, ACE} <- Acl],
+    %% TODO: Error check authz results
+    %% FURTHER TODO: this probably won't work with our hacked ace records :'(
+    [ oc_chef_authz:set_ace_for_entity(superuser, ResourceType, AuthzId, Method, ACE) ||
+        {Method, ACE} <- Acl1],
+    {Cache, []};
+process_policy_step({acls, Steps}, _Org, _User, Cache) ->
+    {Cache, process_acls(Steps)}.
+
+objectlist_to_authz(C, Type, BareObjectList) ->
+    [find({Type,O},C) || O <- lists:flatten(BareObjectList)].
+
+ace_to_authz(C, #mover_hr_ace{clients=Clients, users=Users, groups=Groups}) ->
+    {_, ClientIds} = lists:unzip(objectlist_to_authz(C, client, Clients)),
+    {_, UserIds} = lists:unzip(objectlist_to_authz(C, user, Users)),
+    {_, GroupIds} = lists:unzip(objectlist_to_authz(C, group, Groups)),
+    ActorIds = lists:flatten([ClientIds, UserIds]),
+    #authz_ace{actors=ActorIds,groups=GroupIds}.
+
+
+%%
+%% Sequence of operations to create an object in authz and in chef sql.
+%%
+create_object(_, _, _, [], Cache) ->
+    Cache;
+create_object(OrgId, RequestorId, Type, [Name|Remaining], Cache) ->
+    case create_helper(OrgId, RequestorId, Type, Name) of
+        AuthzId when is_binary(AuthzId) ->
+            NewCache = add_cache(Cache,{Type, Name}, AuthzId),
+            create_object(OrgId, RequestorId, Type, Remaining, NewCache);
+        Error ->
+            %% Do we clean up created authz stuff here, or save it for
+            %% general org deletion routine later?
+            lager:error("Could not create object ~p during policies containers migration of org ~s",
+                        [{Type, Name}, OrgId]),
+            throw(Error)
+    end.
+
+create_helper(OrgId, RequestorId, Type, Name) when is_atom(Name) ->
+    BinaryName = atom_to_binary(Name, utf8),
+    create_helper(OrgId, RequestorId, Type, BinaryName);
+create_helper(OrgId, RequestorId, Type, Name) ->
+    case oc_chef_authz:create_resource(RequestorId, Type) of
+        {ok, AuthzId} ->
+            create_chef_side(OrgId, RequestorId, Type, Name, AuthzId);
+        {error, _} = Error ->
+            Error
+    end.
+
+create_chef_side(OrgId, RequestorId,  container, Name, AuthzId) ->
+    Object = new_container_record(OrgId, AuthzId, Name, RequestorId),
+    create_insert(Object, AuthzId, RequestorId).
+
+create_insert(#mover_chef_container{} = Object, AuthzId, _RequestorId) ->
+    case chef_sql_create_container(chef_object_flatten_container(Object)) of
+        {ok, 1} ->
+            AuthzId;
+        Error ->
+            {chef_sql, {Error, Object}}
+    end.
+
+%%
+%% Helper for creating acls. It's very tedious to write them all out longhand.
+%%
+%% We keep the human readable names throughout this expansion.  We could probably be more
+%% efficient to translate to authz ids earlier, at the cost of a lot of readability
+process_acls(AclDesc) ->
+    AclMap = lists:foldl(fun update_acl_step/2, dict:new(), lists:flatten(AclDesc)),
+    [{set_acl_expanded, Object, Acl} || {Object, Acl} <- dict:to_list(AclMap)].
+
+%% Syntax:
+%% {add_acl, Objects, Actions, Members}
+%%
+%% Objects: [{type, Name} ...]
+%% Actions: List of actions to permit (create, read, update, delete, grant)
+%% Members: {user|client|group, name}
+%% Adds cross product to existing world
+%%
+%% TODO: There's a lot of common code for ACLs between the ACL endpoint and here.
+%% We should extract that code, and expose it as programmatic API for ACL manipulation for
+%% use in the future orgmapper replacement.
+update_acl_step({add_acl, Objects, Actions, Members}, Acls) ->
+    %% split out actors and groups separately
+    {Clients, Users, Groups} = lists:foldl(
+                                 fun(M, {C, U, G}) ->
+                                         case M of
+                                             {user, N} ->
+                                                 {C, [N|U],G};
+                                             {client, N} ->
+                                                 {[N|C], U, G};
+                                             {group, N} ->
+                                                 {C, U, [N|G]}
+                                         end
+                                 end, {[], [], []}, lists:flatten(Members)),
+    AceToAdd = #mover_hr_ace{clients=Clients, users=Users, groups=Groups},
+    ObjUpdate = fun(Acl) ->
+                           update_acl(Acl, Actions, AceToAdd)
+                   end,
+    lists:foldl(fun(Object, Acc) ->
+                        update_acl_for_object(ObjUpdate, Acc, Object)
+                end,
+                Acls, lists:flatten(Objects)).
+
+update_acl(Acl, Actions, AceToAdd) ->
+    UpdateFun = fun(Ace) ->
+                        add_to_ace(Ace, AceToAdd)
+                end,
+    lists:foldl(fun(Action, AAcl) ->
+                        update_ace_by_action(UpdateFun, AAcl, Action)
+                end,
+                Acl, lists:flatten(Actions)).
+
+% lookup acl for object, create new if missing, apply function, and set it
+update_acl_for_object(UpdateFun, Acls, Object) ->
+    Acl0 = case dict:find(Object, Acls) of
+               {ok, V} -> V;
+               error -> []
+           end,
+    Acl1 = UpdateFun(Acl0),
+    dict:store(Object, Acl1, Acls).
+
+% lookup ace for action, create new if missing, apply function, and set it
+update_ace_by_action(UpdateFun, Acl, Action) ->
+    Ace0 = case lists:keyfind(Action, 1, Acl) of
+                         false -> #mover_hr_ace{};
+                         {_, A} -> A
+                     end,
+    Ace1 = UpdateFun(Ace0),
+    lists:keystore(Action, 1, Acl, {Action, Ace1}).
+
+merge(Old, New) ->
+    lists:umerge(Old, lists:sort(New)).
+
+add_to_ace(#mover_hr_ace{clients=OClients, users=OUsers, groups=OGroups},
+           #mover_hr_ace{clients=Clients, users=Users, groups=Groups}) ->
+    NClients = merge(OClients, Clients),
+    NUsers = merge(OUsers, Users),
+    NGroups = merge(OGroups, Groups),
+    #mover_hr_ace{clients=NClients, users=NUsers, groups=NGroups}.
+
+%%
+%% Simple cache for managing object-> authzid mapping.
+%%
+%% This is 'scoped' in terms of the org being created, and the  entries
+%% here implicitly contain the org id.
+%% Most objects are {Type, Name} pairs, such as {user, creator} or {container, nodes}
+%% and are mapped to {ResourceType, AuthzId} pairs (e.g. {object, a452dfadsfa} )
+
+init_cache(#mover_org{authz_id=OrgAuthzId},
+           #mover_requestor{authz_id=CreatorAuthzId}) ->
+    %% Notes: we assume the creator is a superuser;
+    Elements = [ { {user, creator}, CreatorAuthzId },
+                 { {organization}, OrgAuthzId } ],
+    InsertFun = fun({Item,AuthzId}, Acc) ->
+                        add_cache(Acc, Item, AuthzId)
+                end,
+    lists:foldl(InsertFun, dict:new(), Elements).
+
+add_cache(C, {Type, Object}, AuthzId) ->
+    Resource = oc_chef_authz:object_type_to_resource(Type),
+    set({Type, Object}, {Resource, AuthzId}, C);
+add_cache(C, {Type}, AuthzId) ->
+    Resource = oc_chef_authz:object_type_to_resource(Type),
+    set({Type}, {Resource, AuthzId}, C).
+
+
+
+set(Key, Value, C) ->
+    dict:store(Key,Value, C).
+
+find(Key, C) ->
+    case dict:find(Key,C) of
+        {ok, Value} -> Value;
+        error ->
+            lager:error("Error processing org creation policy, no definition found for ~p", [Key]),
+            throw( {error, bad_org_creation_policy})
+    end.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Vendored from oc_chef_container, chef_object_base, chef_sql
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+new_container_record(OrgId, AuthzId, Name, RequestorId) ->
+    %% Now = chef_object_base_sql_date(now),
+    Now = os:timestamp(),
+    Id = chef_object_base_make_org_prefix_id(OrgId, Name),
+    #mover_chef_container{id = Id,
+                          authz_id = AuthzId,
+                          org_id = OrgId,
+                          name = Name,
+                          last_updated_by = RequestorId,
+                          created_at = Now,
+                          updated_at = Now}.
+
+%% vendored from chef_object_base
+chef_object_base_make_org_prefix_id(OrgId, Name) ->
+    %% assume couchdb guid where trailing part has uniqueness
+    <<_:20/binary, OrgSuffix:12/binary>> = OrgId,
+    Bin = iolist_to_binary([OrgId, Name, crypto:rand_bytes(6)]),
+    <<ObjectPart:80, _/binary>> = crypto:hash(md5, Bin),
+    iolist_to_binary(io_lib:format("~s~20.16.0b", [OrgSuffix, ObjectPart])).
+
+%% TODO: epgsql was blowing up trying to convert the output of this to a
+%% DATETIME, but it happily accepts an os:timestamp(). Yet this works just fine
+%% in oc_erchef. Should probably figure out what's going on.
+%%
+%%  chef_object_base_sql_date(now) ->
+%%      chef_object_base_sql_date(os:timestamp());
+%%  chef_object_base_sql_date(DateString) when is_binary(DateString) ->
+%%      DateString;
+%%  chef_object_base_sql_date({_,_,_} = TS) ->
+%%      {{Year,Month,Day},{Hour,Minute,Second}} = calendar:now_to_universal_time(TS),
+%%      iolist_to_binary(io_lib:format("~4w-~2..0w-~2..0w ~2..0w:~2..0w:~2..0w",
+%%                    [Year, Month, Day, Hour, Minute, Second])).
+
+chef_object_flatten_container(ObjectRec) ->
+    [_RecName|Tail] = tuple_to_list(ObjectRec),
+    %% We detect if any of the fields in the record have not been set
+    %% and throw an error
+    case lists:any(fun is_undefined/1, Tail) of
+        true -> error({undefined_in_record, ObjectRec});
+        false -> ok
+    end,
+    Tail.
+
+
+is_undefined(undefined) ->
+    true;
+is_undefined(_) ->
+    false.
+
+chef_sql_create_container(Args) ->
+    sqerl:execute(insert_container_sql(), Args).
+

--- a/src/mover_reindex_dry_run_prep_migration_callback.erl
+++ b/src/mover_reindex_dry_run_prep_migration_callback.erl
@@ -3,6 +3,7 @@
 -export([
 	  migration_init/0,
          migration_type/0,
+         needs_account_dets/0,
          supervisor/0,
          migration_start_worker_args/2,
          error_halts_migration/0,
@@ -55,6 +56,9 @@ next_object() ->
 
 migration_type() ->
     <<"reindex_migration_prep">>.
+
+needs_account_dets() ->
+    true.
 
 supervisor() ->
     mover_transient_worker_sup.

--- a/src/mover_reindex_prep_migration_callback.erl
+++ b/src/mover_reindex_prep_migration_callback.erl
@@ -3,6 +3,7 @@
 -export([
 	  migration_init/0,
          migration_type/0,
+         needs_account_dets/0,
          supervisor/0,
          migration_start_worker_args/2,
          error_halts_migration/0,
@@ -54,6 +55,9 @@ next_object() ->
 
 migration_type() ->
     <<"reindex_migration_prep">>.
+
+needs_account_dets() ->
+    true.
 
 supervisor() ->
     mover_transient_worker_sup.

--- a/src/mover_reindex_prep_migration_callback.erl
+++ b/src/mover_reindex_prep_migration_callback.erl
@@ -1,3 +1,5 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil;fill-column: 92 -*-
+%% ex: ts=4 sw=4 et
 -module(mover_reindex_prep_migration_callback).
 
 -export([

--- a/src/mover_transient_queue_batch_migrator.erl
+++ b/src/mover_transient_queue_batch_migrator.erl
@@ -22,7 +22,7 @@ migrate_all(CallbackMod) ->
     application:set_env(mover, sleep_time, 0),
 
     % Build dets tables
-    mover_manager:create_account_dets(),
+    mover_manager:create_account_dets(CallbackMod),
 
     run_migration(CallbackMod).
 

--- a/src/mover_transient_worker.erl
+++ b/src/mover_transient_worker.erl
@@ -46,8 +46,11 @@ migrate(timeout, #state{processor_args = ProcessorArgs, callback_module = Callba
             stop_with_failure(State#state{results = Error}, Error, migrate)
     catch
         ErrorType:Reason ->
-            io:fwrite("died in mover_transient_worker:migrate/2:~n~p~n~p~n", [ErrorType, Reason]),
-            io:fwrite("~p~n", [erlang:get_stacktrace()]),
+            HeadlineIoList = io_lib:fwrite("Error in ~p:migration_action", [CallbackModule]),
+            Headline = lists:flatten(HeadlineIoList),
+            error_logger:error_report({migration_action, Headline}),
+            error_logger:error_msg("migration_action args~n~p~n", [ProcessorArgs]),
+            error_logger:error_msg("~p~n~p~n~p~n", [ErrorType, Reason, erlang:get_stacktrace()]),
             stop_with_failure(State#state{results = Reason}, Reason, migrate)
     end.
 

--- a/src/mover_transient_worker.erl
+++ b/src/mover_transient_worker.erl
@@ -45,7 +45,9 @@ migrate(timeout, #state{processor_args = ProcessorArgs, callback_module = Callba
         Error ->
             stop_with_failure(State#state{results = Error}, Error, migrate)
     catch
-        _ErrorType:Reason ->
+        ErrorType:Reason ->
+            io:fwrite("died in mover_transient_worker:migrate/2:~n~p~n~p~n", [ErrorType, Reason]),
+            io:fwrite("~p~n", [erlang:get_stacktrace()]),
             stop_with_failure(State#state{results = Reason}, Reason, migrate)
     end.
 

--- a/src/mv_oc_chef_authz.erl
+++ b/src/mv_oc_chef_authz.erl
@@ -1,0 +1,714 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
+%% ex: ts=4 sw=4 et
+%% @author Mark Anderson <mark@opscode.com>
+%% @author Marc Paradise <marc@getchef.com>
+%% @doc authorization - Interface to the opscode authorization servize
+%%
+%% This module is an Erlang port of the mixlib-authorization Ruby gem.
+%%
+%% Copyright 2011-2014 Chef Software, Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% VENDORED copy of oc_chef_authz, copied from oc_erchef at
+%% d0fa517e23483ca9555721a0ebae681e30f9d104 (tag 1.6.4).
+%%
+%% Functions and record types will be slightly modified to meet the needs of
+%% mover_policies_containers_creation_callback.
+%%
+%% Any code with an external dependency on oc_chef_authz_db has been commented
+%% out. If you need that code, feel free to uncomment it, but be sure to vendor
+%% oc_chef_authz_db as well.
+%%
+%% You should not need to modify this code in any breaking way unless there is
+%% a breaking change in the bifrost/authz HTTP API.
+%%
+%% If you are writing a migration that needs a future version of this code,
+%% re-vendor it as mv_oc_chef_authz_1 or similar.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+-module(mv_oc_chef_authz).
+
+-include("mv_oc_chef_authz.hrl").
+
+%
+% TODO:
+%
+% Helper function to ADD/DELETE actors and groups from record
+% (expecting we won't want to make everyone do this common task
+
+
+-export([
+         %% add_client_to_clients_group/4,
+         add_to_group/4,
+         bulk_actor_is_authorized/5,
+         create_resource/2,
+         delete_resource/3,
+         %% create_entity_if_authorized/4,
+         %% get_container_aid_for_object/3,
+         %% make_context/2,
+         is_authorized_on_resource/6,
+         ping/0,
+         remove_actor_from_actor_acl/2,
+         remove_ace_for_entity/6,
+         add_ace_for_entity/6,
+         set_ace_for_entity/5,
+         superuser_id/0,
+         object_type_to_resource/1,
+         pluralize_resource/1
+        ]).
+
+-ifdef(TEST).
+-compile([export_all]).
+-endif.
+
+-export_type([oc_chef_authz_context/0]).
+
+-define(x_ops_requester_id, "X-Ops-Requesting-Actor-Id").
+-define(x_ops_user_id, "X-Ops-User-Id").
+-define(x_ops_user_id_value, "front-end-service").
+-define(atom_bin_perms, [{create, <<"create">>},
+                         {read, <<"read">>},
+                         {update, <<"update">>},
+                         {delete, <<"delete">>},
+                         {grant, <<"grant">>}]).
+
+%-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+%-endif.
+
+-type contained_object_name() :: 'client' |
+                                 'container' |
+                                 'cookbook' |
+                                 'data' |
+                                 'environment'|
+                                 'group' |
+                                 'node' |
+                                 'role' |
+                                 'sandboxes' |
+                                 'search' |
+                                 'user' |
+                                 'policies' |
+                                 'cookbook_artifacts'.
+
+-spec ping() -> pong | pang.
+ping() ->
+    mv_oc_chef_authz_http:ping().
+
+%%  -spec make_context(binary(), term()) -> #oc_chef_authz_context{}.
+%%  make_context(ReqId, Darklaunch)  ->
+%%      oc_chef_authz_db:make_context(ReqId, Darklaunch).
+
+-spec superuser_id() -> oc_authz_id().
+superuser_id() ->
+    envy:get(oc_chef_authz, authz_superuser_id, binary).
+
+-spec requestor_or_superuser(object_id() | superuser) -> oc_authz_id().
+requestor_or_superuser(superuser) ->
+    superuser_id();
+requestor_or_superuser(ObjectId) ->
+    ObjectId.
+
+%%%%  %% @doc Creates a new Authz entity, if the requestor has the necessary permissions.
+%%%%  %%
+%%%%  %% `Creator' either a requestor ID or the atom 'superuser'.  It should only be the superuser
+%%%%  %% when the requestor is a validator client, and we're trying to create a new client.
+%%%%  %% (Currently, callers are responsible for making this call.)  If that is the case, the
+%%%%  %% entity created does NOT have the superuser in its ACL.  In all other cases, the creating
+%%%%  %% actor IS present in the new entity's ACL.
+%%%%  %%
+%%%%  %% If the `Creator' is the Authz superuser, it is by definition authorized to create a new
+%%%%  %% entity; a request to Authz is not issued,(such a request would fail anyway, due to the
+%%%%  %% shape of the current Authz API, and because the superuser ID is not present in any ACL
+%%%%  %% anywhere).
+%%%%  %%
+%%%%  %% `ObjectType' is used to determine what kind of Authz entity should be created (e.g., a
+%%%%  %% client should be an actor, while a node should be an object, etc.).
+%%%%  %%
+%%%%  %% If the permissions are in place, the Authz ID of the newly-created entity is returned.
+%%%%  -spec create_entity_if_authorized(oc_chef_authz_context(),
+%%%%                                    OrgId :: object_id(),
+%%%%                                    Creator :: superuser | object_id(),
+%%%%                                    ObjectType :: contained_object_name()) ->
+%%%%                                           {ok, object_id()} |
+%%%%                                           {error, forbidden}.
+%%%%  create_entity_if_authorized(Context, OrgId, superuser, ObjectType) ->
+%%%%      ContainerAId = get_container_aid_for_object(Context, OrgId, ObjectType),
+%%%%      AuthzSuperuserId = superuser_id(),
+%%%%      %% We skip is_authorized_on_resource check as an optimization
+%%%%      create_entity_with_container_acl(AuthzSuperuserId, ContainerAId, ObjectType);
+%%%%  create_entity_if_authorized(Context, OrgId, CreatorAId, ObjectType) ->
+%%%%      ContainerAId = get_container_aid_for_object(Context, OrgId, ObjectType),
+%%%%      case is_authorized_on_resource(CreatorAId, container,
+%%%%                                     ContainerAId, actor, CreatorAId, create) of
+%%%%          false ->
+%%%%              {error, forbidden};
+%%%%          true ->
+%%%%              create_entity_with_container_acl(CreatorAId, ContainerAId, ObjectType)
+%%%%      end.
+%%%%
+%%%%  %%%
+%%%%  %%% get_container_aid_for_object
+%%%%  %%% TODO: consider error cases in more detail
+%%%%  -spec get_container_aid_for_object(oc_chef_authz_context(),
+%%%%                                     object_id(),
+%%%%                                     contained_object_name()) ->
+%%%%                                            object_id().
+%%%%  get_container_aid_for_object(Context, OrgId, ObjectType) ->
+%%%%      ContainerName = object_type_to_container_name(ObjectType),
+%%%%      Container = oc_chef_authz_db:fetch_container(Context, OrgId, ContainerName),
+%%%%      Container#chef_container.authz_id.
+
+%%%%  %% @doc Create a new Authz entity using the ACL of a container as a template for the new
+%%%%  %% entity's ACL.
+%%%%  %%
+%%%%  %% `RequestorId' will have all permissions on the new object.  The permissions associated
+%%%%  %% with the ACL for `ContainerAId' will be merged into the ACL for the new object.
+%%%%  %%
+%%%%  %% @end TODO: consider error cases in more detail
+%%%%  -spec create_entity_with_container_acl(RequestorId::requestor_id(),
+%%%%                                         ContainerAId::object_id(),
+%%%%                                         ObjectType :: 'client' | 'container' |
+%%%%                                                       'cookbook' | 'data' | 'environment' |
+%%%%                                                       'group' | 'node' | 'role' | 'search' | 'user'
+%%%%                                                       ) -> {ok, object_id()} | {error, forbidden}.
+%%%%  create_entity_with_container_acl(RequestorId, ContainerAId, ObjectType) ->
+%%%%
+%%%%      %% Create the entity
+%%%%      AuthzType = object_type_to_resource(ObjectType),
+%%%%      {ok, Id} = create_resource(RequestorId, AuthzType),
+%%%%
+%%%%      %% Ensure it inherits the ACL of its container
+%%%%      case merge_acl_from_container(RequestorId, ContainerAId, AuthzType, Id) of
+%%%%          ok ->
+%%%%              {ok, Id};
+%%%%          {error, object_acl} ->
+%%%%              error_logger:error_msg("Unable to read ACL for newly created ~p: ~p~n", [ObjectType, Id]),
+%%%%              {error, forbidden};
+%%%%          Error ->
+%%%%              error_logger:error_msg("Error encountered when trying to merge container ACL: ~p~n", [Error]),
+%%%%              {error, forbidden}
+%%%%      end.
+
+%%%%  %% @doc Merges the ACL of an entity's container with the ACL of the entity itself.
+%%%%  %%
+%%%%  %% Currently is only used for actors and objects, since those are the only kinds of Authz
+%%%%  %% entities we currently create via Erchef.
+%%%%  %%
+%%%%  %% Nothing in this method checks that the `ContainerId' and the `ObjectId' correspond
+%%%%  %% properly (e.g., that an object id that represents a Node implies that the container id is
+%%%%  %% that of the organization's node container).  That correspondence is assumed to have been
+%%%%  %% verified elsewhere.
+%%%%  %%
+%%%%  %% @end TODO: consider error cases in more detail
+%%%%  -spec merge_acl_from_container(requestor_id(),
+%%%%                                 ContainerId :: object_id(),
+%%%%                                 AuthzType :: 'actor' | 'object' | 'container' | 'group',
+%%%%                                 ObjectId :: object_id()) -> ok |
+%%%%                                                             {error, object_acl | container_acl}.
+%%%%  merge_acl_from_container(_RequestorId, _ContainerId, container, _ObjectId) ->
+%%%%      %% When creating containers, the new container does NOT inherit the ACLs from the
+%%%%      %% parent container.
+%%%%      ok;
+%%%%  merge_acl_from_container(RequestorId, ContainerId, AuthzType, ObjectId) ->
+%%%%      case get_acl_for_resource(RequestorId, container, ContainerId) of
+%%%%          {ok, CAcl} ->
+%%%%              case get_acl_for_resource(RequestorId, AuthzType, ObjectId) of
+%%%%                  {ok, OAcl} ->
+%%%%                      NAcl = merge_acl(CAcl, OAcl),
+%%%%                      case set_acl(RequestorId, AuthzType, ObjectId, NAcl) of
+%%%%                          ok ->
+%%%%                              ok;
+%%%%                          {error, _} ->
+%%%%                              %% The details of the error will have already been logged
+%%%%                              {error, object_acl}
+%%%%                      end;
+%%%%                  Error ->
+%%%%                      error_logger:error_msg("Error fetching ACL on object ~p for requestor ~p: ~p~n",
+%%%%                                             [ObjectId, RequestorId, Error]),
+%%%%                      {error, object_acl}
+%%%%              end;
+%%%%          Error ->
+%%%%              error_logger:error_msg("Error fetching ACL on container ~p for requestor ~p: ~p~n",
+%%%%                                     [ContainerId, RequestorId, Error]),
+%%%%              {error, container_acl}
+%%%%      end.
+
+%% @doc Set the ACL of the entity to the given ACL, one ACE at a time.
+%%
+%% Returns 'ok' if all ACEs are successfully set, and {error, Reason} at the first failure.
+%%
+%% No, this is not transactional in any sense, but then again, neither is CouchDB.  In any
+%% case, this will change dramatically once we move to SQL.
+-spec set_acl(requestor_id(),
+              AuthzType :: 'actor' | 'object' | 'container' | 'group',
+              ObjectId :: object_id(),
+              NewAcl :: authz_acl()) -> ok | {error, any()}.
+set_acl(_RequestorId, _AuthzType, _ObjectId, []) ->
+    ok;
+set_acl(RequestorId, AuthzType, ObjectId, [{Method, ACE}|Rest]) when AuthzType =:= 'actor';
+                                                                     AuthzType =:= 'object';
+                                                                     AuthzType =:= 'container';
+                                                                     AuthzType =:= 'group' ->
+    case set_ace_for_entity(RequestorId, AuthzType, ObjectId, Method, ACE) of
+        ok ->
+            set_acl(RequestorId, AuthzType, ObjectId, Rest);
+        {error, Reason} ->
+            error_logger:error_msg("Error setting ACE ~p for method ~p on ~p ~p for requestor ~p: ~p~n",
+                                   [ACE, Method, AuthzType, ObjectId, RequestorId, Reason]),
+            {error, Reason}
+    end.
+
+%% @doc Determine if the actor with id `ActorId' has `Permission' on each resource object in
+%% the `Resources' list. If the actor has permission on all of the resources, then the atom
+%% `ok' is returned, otherwise, a list of `{false, ResourceData}' tuples are returned. If an
+%% error occurs during a check, the function immediately returns a detailed error tuple.
+-spec bulk_actor_is_authorized(ReqId,
+                               ActorId,
+                               ResourceType,
+                               Resources,
+                               Permission) -> true | {false, [ResourceData]} |
+                                              {error, _} when
+      ReqId :: binary(),
+      ActorId :: actor_id(),
+      ResourceType :: resource_type(),
+      Resources :: [{oc_authz_id(), ResourceData}],
+      ResourceData :: any(),
+      Permission :: access_method().
+bulk_actor_is_authorized(ReqId, ActorId, ResourceType, Resources, Permission) ->
+    Url = <<"bulk">>,
+    {AuthzIds, _Data} = lists:unzip(Resources),
+    EJSON = make_bulk_request_body(ActorId, Permission, ResourceType, AuthzIds),
+    Body = json_encode(EJSON),
+    case mv_oc_chef_authz_http:request(ReqId, Url, post, [], Body, ActorId) of
+        ok -> true;
+        {ok, ResponseBody} ->
+            case ej:get({<<"unauthorized">>}, ResponseBody) of
+                undefined ->
+                    {error, unexpected_body};
+                Unauthorized ->
+                   {false, get_data_for_id(Unauthorized, Resources) }
+            end;
+        {error, Why} ->
+            {error, Why}
+    end.
+
+json_encode(EJSON) ->
+    %% jiffy:encode can return an iolist which breaks the http code. This has only been
+    %% observed with floats, but may occur elsewhere.
+    iolist_to_binary(jiffy:encode(EJSON)).
+
+make_bulk_request_body(RequestorId, Permission, ResourceType, AuthzIds) ->
+    {[{<<"requestor_id">>, RequestorId},
+      {<<"permission">>, Permission},
+      {<<"type">>, ResourceType},
+      {<<"collection">>, AuthzIds}
+     ]}.
+
+%% Fetch Data from Resources for each Id in list of Ids
+%% Resources is a list of Id, Data tuples.
+%% Its an error for an id to appear on the list that isn't in resources
+
+get_data_for_id(Ids, Resources) ->
+    %% Sorting the lists lets us do the extraction in a single pass through the list.
+    get_data_for_id(lists:sort(Ids), lists:sort(Resources), []).
+
+%% Two cases that might be suggested by symmetry should cause a bad match, because they would only happen if
+%% we got an id that wasn't found on the resource list
+%% get_data_for_id(_, [], Acc) ->
+%%   Acc
+%% get_data_for_id([Id | Ids], [{RId, _RData} | _Resources] = OResources, Acc ) when Id < RId -
+%%   get_data_for_id(Ids, OResources, Acc);
+
+%% We've found all the ids.
+get_data_for_id([], _, Acc) ->
+    Acc;
+%% We found a match for the id
+get_data_for_id([Id | Ids], [{Id, RData} | Resources], Acc) ->
+    get_data_for_id(Ids, Resources, [RData | Acc]);
+%% If the current id on the id list sorts later than the one on the resource list, then skip
+%% to next entry on resource list
+get_data_for_id([Id | _Ids] = OIds , [{RId, _RData} | Resources], Acc ) when Id > RId ->
+    get_data_for_id(OIds, Resources, Acc).
+
+%
+% Test if an actor is authorized
+% Corresponds to GET /{actors|containers|groups|objects}/:id/acl/{actors|groups}/:member_id
+%
+-spec is_authorized_on_resource(requestor_id(), resource_type(), object_id(),
+                                'actor'|'group', actor_id(), access_method())
+                               -> true|false|{error,server_error}.
+is_authorized_on_resource(RequestorId, ResourceType, ResourceId, ActorType, ActorId, AccessMethod)
+  when is_atom(ResourceType) and is_atom(ActorType) and is_atom(AccessMethod) ->
+    Url = make_url([pluralize_resource(ResourceType), ResourceId, <<"acl">>,
+                    AccessMethod, pluralize_resource(ActorType), ActorId ] ),
+    case mv_oc_chef_authz_http:request(Url, get, [], [], RequestorId) of
+        ok -> true;
+        %% This api returns not found for any missing permission
+        {error, not_found} -> false;
+        %% Otherwise, we expect server_error; not forbidden
+        {error, server_error} -> {error, server_error}
+    end.
+
+
+%
+% Create entity in authz
+
+%
+% This succeeds unless authz is truly foobared. It doesn't seem to care what the requestor-id is.
+%
+-spec create_resource(requestor_id(), actor|container|group|object) -> {ok, object_id()} |
+                                                                       {error, server_error}.
+create_resource(RequestorId, ResourceType) ->
+    %% authz can return 500, and we'll throw. I think that is correct
+    %% What are the failure modes? Can we succeed and not get a doc?
+    case mv_oc_chef_authz_http:request(pluralize_resource(ResourceType), post, [], [], RequestorId) of
+        %% What are the failure modes? Can we succeed and not get a doc?
+        {ok, IdDoc} -> {ok, ej:get({<<"id">>}, IdDoc)};
+        {error, server_error} -> {error, server_error}
+    end.
+
+%
+% Delete entity in authz
+% Corresponds to DELETE /{actors|groups|objects}/:id
+% No delete for containers...
+-spec delete_resource(requestor_id(), 'actor'|'group'|'object', object_id())
+                     ->  ok | {error, forbidden|not_found|server_error}.
+delete_resource(RequestorId, ResourceType, Id) ->
+    EffectiveRequestorId = requestor_or_superuser(RequestorId),
+    Url = make_url([pluralize_resource(ResourceType), Id]),
+    case mv_oc_chef_authz_http:request(Url, delete, [], [], EffectiveRequestorId) of
+        ok -> ok;
+        %% Expected errors are forbidden, not_found, server_error
+        {error, Error} -> {error, Error}
+    end.
+
+%% Give a resource access to an entity by adding the resource
+%% to the entity's ACE
+-spec add_ace_for_entity(requestor_id(), group|actor, object_id(),
+                         resource_type(), object_id(), access_method()) ->
+    ok | {error, forbidden|not_found|server_error}.
+
+add_ace_for_entity(RequestorId, ResourceType, ResourceId,
+                   EntityType, EntityId, Method) ->
+    update_ace_for_entity(RequestorId, ResourceType, ResourceId,
+                          EntityType, EntityId, Method,
+                          fun add_if_missing/2).
+
+%% Deny a resource access to an entity by adding the resource
+%% to the entity's ACE. Note that if the resource has the access to the
+%% same entity via another means, this will not change
+-spec remove_ace_for_entity(requestor_id(), group|actor, object_id(),
+                         resource_type(), object_id(), access_method()) ->
+    ok | {error, forbidden|not_found|server_error}.
+remove_ace_for_entity(RequestorId, ResourceType, ResourceId,
+                      EntityType, EntityId, Method) ->
+    update_ace_for_entity(RequestorId, ResourceType, ResourceId,
+                          EntityType, EntityId, Method,
+                          fun lists:delete/2).
+
+update_ace_for_entity(RequestorId, ResourceType, ResourceId,
+                      EntityType, EntityId, Method, UpdateFun) ->
+    case get_ace_for_entity(RequestorId, EntityType, EntityId, Method) of
+        {ok, ACE} ->
+            Members = case ResourceType of
+                          group ->
+                              ACE#authz_ace.groups;
+                          actor ->
+                              ACE#authz_ace.actors
+                      end,
+            NewMembers = UpdateFun(ResourceId, Members),
+            NewACE = case ResourceType of
+                         group ->
+                             ACE#authz_ace{groups = NewMembers};
+                         actor ->
+                             ACE#authz_ace{actors = NewMembers}
+                     end,
+            set_ace_for_entity(RequestorId, EntityType, EntityId, Method, NewACE);
+        {error, Error} ->
+            {error, Error}
+    end.
+
+add_if_missing(Item, List) ->
+    case lists:member(Item, List) of
+        true ->
+            List;
+        false ->
+            [Item] ++ List
+    end.
+
+%
+% Get acl from an entity
+% GET {objects|groups|actors|containers}/:id/acl
+%
+-spec get_acl_for_resource(requestor_id(), resource_type(), binary()) ->
+    {ok, authz_acl()}|{error, any()}.
+get_acl_for_resource(RequestorId, ResourceType, Id) ->
+    Url = make_url([pluralize_resource(ResourceType), Id, acl]),
+    case mv_oc_chef_authz_http:request(Url, get, [], [], RequestorId) of
+        {ok, Data} ->
+            Acl=extract_acl(Data),
+            {ok, Acl};
+        %% Expected errors are forbidden, not_found, server_error
+        {error, Error} -> {error, Error}
+    end.
+
+get_ace_for_entity(RequestorId, AuthzType, Id, AccessMethod) ->
+    Url = make_url([pluralize_resource(AuthzType), Id, acl, AccessMethod]),
+    case mv_oc_chef_authz_http:request(Url, get, [], [], RequestorId) of
+        {ok, Data} ->
+            ACE = extract_ace(Data),
+            {ok, ACE};
+        %% Expected errors are forbidden, not_found, server_error
+        {error, Error} -> {error, Error}
+    end.
+
+%
+% Replace the actors and groups of an ace
+% PUT {objects|groups|actors|containers}/:id/acl/:action
+%
+-spec set_ace_for_entity(requestor_id(),
+                         AuthzType :: 'actor' | 'object',
+                         object_id(),
+                         access_method(),
+                         authz_ace()) -> ok |
+                                         {error, any()}.
+set_ace_for_entity(RequestorId, AuthzType, Id, AccessMethod,
+                   #authz_ace{actors=Actors, groups=Groups}) ->
+    EffectiveRequestorId = requestor_or_superuser(RequestorId),
+    Url = make_url([pluralize_resource(AuthzType), Id, acl, AccessMethod]),
+    %% jiffy:encode can return an iolist which breaks the http code. This has only been
+    %% observed with floats, but may occur elsewhere.
+    Body = iolist_to_binary(jiffy:encode({[{<<"actors">>, Actors}, {<<"groups">>, Groups}]})),
+    case mv_oc_chef_authz_http:request(Url, put, [], Body, EffectiveRequestorId) of
+        ok -> ok;
+        %% Expected errors are forbidden, not_found, server_error
+        {error, Error} -> {error, Error}
+    end.
+
+%%%%  %% @doc Adds the given client authz ID to the actors list of the organization's "clients"
+%%%%  %% group.  Clients must be members of this group in order to behave properly as such.
+%%%%  %%
+%%%%  %% `RequestorId' can be the atom `superuser'; in that case, the underlying Authz requests
+%%%%  %% will be made by the Authz superuser.  If it is a normal ID, that requestor will make the
+%%%%  %% Authz requests.
+%%%%  -spec add_client_to_clients_group(#oc_chef_authz_context{},
+%%%%                                   OrgId :: object_id(),
+%%%%                                   ClientAuthzId :: object_id(),
+%%%%                                   RequestorId :: superuser | object_id()) ->
+%%%%                                            ok | {error, term()}.
+%%%%  add_client_to_clients_group(Context, OrgId, ClientAuthzId, RequestorId) ->
+%%%%      %% We need the superuser ID here because when a validator creates a client, the won't
+%%%%      %% have the permissions required to add that new client to the clients group.
+%%%%      ClientGroupAuthzId = oc_chef_authz_db:fetch_group_authz_id(Context, OrgId, <<"clients">>),
+%%%%      add_to_group(ClientGroupAuthzId, actor, ClientAuthzId, RequestorId).
+%%%%
+
+%% @doc Add actor or group to group.
+%%
+%% `RequestorId' can be the atom `superuser'; in that case, the underlying Authz requests
+%% will be made by the Authz superuser.  If it is a normal ID, that requestor will make the
+%% Authz requests.
+%%
+
+-spec add_to_group(GroupId :: object_id(),
+                   Type :: actor | group,
+                   AuthzId :: object_id(),
+                   RequestorId :: superuser | object_id()) ->
+                          ok | {error, term()}.
+add_to_group(GroupAuthzId, Type, AuthzId, RequestorId) ->
+    %% Refactor maybe?
+    EffectiveRequestorId = requestor_or_superuser(RequestorId),
+    PType = pluralize_resource(Type),
+    Url = make_url([<<"groups">>, GroupAuthzId, PType, AuthzId]),
+    case mv_oc_chef_authz_http:request(Url, put, [], [], EffectiveRequestorId) of
+        ok             -> ok;
+        {error, Error} -> {error, Error}
+    end.
+
+
+
+%% @doc As a given actor (`TargetActorId'), remove another actor (`ActorIdToRemove')
+%% completely from its ACL.
+%%
+%% This is originally intended to support the case of removing a validator client from its
+%% own ACL.  We only want the validator to be able to create a new non-validator client, and
+%% we really mean it!
+%%
+%% Both `TargetActorId' and `ActorIdToRemove' are assumed here to be the AuthzId of actors,
+%% not any other kind of Authz object (group, container, or object).  This should be
+%% verified by callers of this function.
+-spec remove_actor_from_actor_acl(ActorIdToRemove::object_id(),
+                                  TargetActorId::object_id()) -> ok | {error, any()}.
+remove_actor_from_actor_acl(ActorIdToRemove, TargetActorId) ->
+    %% Target actor fetches its own ACL
+    {ok, Acl} = get_acl_for_resource(TargetActorId, actor, TargetActorId),
+    FilteredAcl = remove_actor_from_acl(ActorIdToRemove, Acl),
+
+    %% Target actor updates its own ACL
+    set_acl(TargetActorId, actor, TargetActorId, FilteredAcl).
+
+%% @doc Front-end to recursive implementation in `remove_actor_from_acl/3`.
+-spec remove_actor_from_acl(ActorId::object_id(), Acl::authz_acl()) -> authz_acl().
+remove_actor_from_acl(ActorId, Acl) ->
+    remove_actor_from_acl(ActorId, Acl, []).
+
+%% @doc Removes `ActorId` from all `actors` lists in the given ACL.
+-spec remove_actor_from_acl(ActorId::object_id(),
+                            AclToProcess:: [] | authz_acl(),
+                            FilteredAcl::[] | authz_acl()) ->
+                                   authz_acl().
+remove_actor_from_acl(_ActorId, [], Acc) ->
+    lists:reverse(Acc);
+remove_actor_from_acl(ActorId, [{Permission, Ace}|Rest], Acc) ->
+    Filtered = remove_actor_from_ace(ActorId, Ace),
+    remove_actor_from_acl(ActorId, Rest, [{Permission, Filtered} | Acc]).
+
+%% @doc Returns the given authz_ace with `ActorId' filtered out of the `actors' list.  The
+%% `groups' list is untouched.
+-spec remove_actor_from_ace(ActorId::object_id(), Ace::#authz_ace{}) -> #authz_ace{}.
+remove_actor_from_ace(ActorId, #authz_ace{actors=Actors, groups=Groups}) ->
+    #authz_ace{actors=[A || A <- Actors, A /= ActorId],
+               groups=Groups}.
+
+-spec pluralize_resource(resource_type()) -> <<_:48,_:_*8>>.
+pluralize_resource(actor)     -> <<"actors">>;
+pluralize_resource(container) -> <<"containers">>;
+pluralize_resource(group)     -> <<"groups">>;
+pluralize_resource(object)    -> <<"objects">>.
+
+%%%%  -spec object_type_to_container_name(contained_object_name()) -> <<_:32,_:_*8>>.
+%%%%  object_type_to_container_name(client)            -> <<"clients">>;
+%%%%  object_type_to_container_name(container)         -> <<"containers">>;
+%%%%  object_type_to_container_name(cookbook)          -> <<"cookbooks">>;
+%%%%  object_type_to_container_name(data)              -> <<"data">>; % breaks the simple atom() + s strategy
+%%%%  object_type_to_container_name(environment)       -> <<"environments">>;
+%%%%  object_type_to_container_name(group)             -> <<"groups">>;
+%%%%  object_type_to_container_name(node)              -> <<"nodes">>;
+%%%%  object_type_to_container_name(organization)      -> <<"organizations">>;
+%%%%  object_type_to_container_name(role)              -> <<"roles">>;
+%%%%  object_type_to_container_name(sandbox)           -> <<"sandboxes">>;
+%%%%  object_type_to_container_name(search)            -> <<"search">>;
+%%%%  object_type_to_container_name(user)              -> <<"users">>;
+%%%%  object_type_to_container_name(policies)          -> <<"policies">>;
+%%%%  object_type_to_container_name(policy_group)          -> <<"policy_groups">>;
+%%%%  object_type_to_container_name(cookbook_artifact) -> <<"cookbook_artifacts">>.
+
+%% @doc The authz system needs to know the resource type as part of the API. This maps chef
+%% object types into their appropriate authz resource types.
+%%
+%% When creating a new Authz entity in a given container, we need to ensure we're creating
+%% the correct kind.
+-spec object_type_to_resource(contained_object_name()) -> atom().
+object_type_to_resource(client)    -> 'actor';
+object_type_to_resource(container) -> 'container';
+object_type_to_resource(group)     -> 'group';
+object_type_to_resource(user)      -> 'actor';
+object_type_to_resource(_)         -> 'object'.
+
+%
+% This exists for testing and debugging; it's too expensive for day to day use.
+% TODO:
+% write: auth_id_to_object(Server, OrgId, AuthId) ->
+%
+-spec to_text(atom() | binary() | string()) -> string().
+to_text(E) when is_binary(E) ->
+    binary_to_list(E);
+to_text(E) when is_atom(E) ->
+    atom_to_list(E);
+to_text(E) when is_list(E) ->
+    E.
+
+-spec make_url([string()|binary()|atom(),...]) -> string().
+make_url(Components) ->
+    string:join([to_text(E) || E <- Components],"/").
+
+% Extract actors and groups from the
+% TODO refine spec
+% todo add error handling
+%% The return type should always be `{[binary()], [binary()]}' but since we are extracting
+%% from a JSON blob using ej, dialyzer has no way to verify that so we have to use a broader
+%% spec.
+-spec extract_actors_and_groups(ej:json_object()) -> {ej:json_term(), ej:json_term()} | error.
+extract_actors_and_groups(JsonBlob) ->
+    Actors = ej:get({<<"actors">>}, JsonBlob),
+    Groups = ej:get({<<"groups">>}, JsonBlob),
+    case Actors =:= undefined orelse Groups =:= undefined of
+        true -> error;
+        false -> {Actors, Groups}
+    end.
+
+-spec extract_ace(ej:json_object()) -> authz_ace().
+extract_ace(JsonBlob) ->
+    {Actors, Groups} = extract_actors_and_groups(JsonBlob),
+    #authz_ace{actors=Actors, groups=Groups}.
+
+-spec extract_acl({}) -> authz_acl().
+extract_acl(JsonBlob) ->
+    [ {PAtom, extract_ace(ej:get({PBin},JsonBlob))} || {PAtom, PBin} <- ?atom_bin_perms ].
+
+%
+% This is needed by the container permission inheritance
+%
+-spec merge_ace(authz_ace(), authz_ace()) -> authz_ace().
+merge_ace(#authz_ace{actors=Ace1Actors, groups=Ace1Groups},
+          #authz_ace{actors=Ace2Actors, groups=Ace2Groups}) ->
+    #authz_ace{
+           actors=lists:usort(Ace1Actors ++ Ace2Actors),
+           groups=lists:usort(Ace1Groups ++ Ace2Groups)
+    }.
+
+-spec merge_acl(authz_acl(), authz_acl()) -> authz_acl().
+merge_acl(Acl1, Acl2) ->
+    [{K, merge_ace(A,B)} || {{K, A}, {K, B}} <- lists:zip(Acl1, Acl2)].
+
+
+%% unit tests for internal functions
+-ifdef(TEST).
+extract_acl_test() ->
+    {ok, AclJson} = file:read_file("../test/example_container_acl.json"),
+    RawAcl = jiffy:decode(AclJson),
+    Acl = extract_acl(RawAcl),
+    [ ?assertEqual(true, lists:keymember(Perm, 1, Acl)) || Perm <- ?access_methods ],
+    ReadAce = proplists:get_value(read, Acl),
+    ?assertEqual(ReadAce#authz_ace.actors, [<<"5360afaf2d6bace8609f0e3df100086a">>]),
+    ?assertEqual(lists:sort(ReadAce#authz_ace.groups),
+                 lists:sort([<<"5360afaf2d6bace8609f0e3df1c18c1c">>,
+                             <<"5360afaf2d6bace8609f0e3df1c1094a">>,
+                             <<"5360afaf2d6bace8609f0e3df1c1555d">>])).
+
+merge_acl_test_() ->
+    {ok, ContainerAclJson} = file:read_file("../test/example_container_acl.json"),
+    RawContainerAcl = jiffy:decode(ContainerAclJson),
+    ContainerAcl = extract_acl(RawContainerAcl),
+
+    {ok, NodeAclJson} = file:read_file("../test/example_node_acl.json"),
+    RawNodeAcl = jiffy:decode(NodeAclJson),
+    NodeAcl = extract_acl(RawNodeAcl),
+
+    MergedAcl = merge_acl(ContainerAcl, NodeAcl),
+
+    ReadAce = proplists:get_value(read, MergedAcl),
+    ExpectedActors = [<<"5360afaf2d6bace8609f0e3df100086a">>,
+                      <<"5360afaf2d6bace8609f0e3df13e7e8e">>],
+    ExpectedGroups = [<<"5360afaf2d6bace8609f0e3df1c18c1c">>,
+                      <<"5360afaf2d6bace8609f0e3df1c1094a">>,
+                      <<"5360afaf2d6bace8609f0e3df1c1555d">>],
+    [ ?_assertEqual(true, lists:member(Actor, ReadAce#authz_ace.actors)) || Actor <- ExpectedActors ] ++
+    [ ?_assertEqual(true, lists:member(Group, ReadAce#authz_ace.groups)) || Group <- ExpectedGroups ] ++
+    [ ?_assertEqual(true, lists:keymember(Perm, 1, MergedAcl)) || Perm <- ?access_methods ].
+
+-endif.

--- a/src/mv_oc_chef_authz.hrl
+++ b/src/mv_oc_chef_authz.hrl
@@ -1,0 +1,64 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% VENDORED Records and Types
+%%
+%% Replaces dependency in oc_chef_authz:
+%%      -include("../../include/oc_chef_authz.hrl").
+%%      -include("oc_chef_authz_db.hrl").
+%%
+%% Copied from oc_erchef 1.6.4 d0fa517e23483ca9555721a0ebae681e30f9d104
+%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+-type resource_type() :: 'actor'|'container'|'group'|'object'.
+-type access_method() :: 'create'|'read'|'update'|'delete'|'grant'.
+-type actor_list() :: [ binary() ].
+-type group_list() :: [ binary() ].
+
+-type oc_authz_id() :: <<_:256>>.
+
+-record(authz_group, {actors = [] :: actor_list(),
+		      groups = [] :: group_list()}).
+
+-record(authz_ace,  {actors = [] :: actor_list(),
+		     groups = [] :: group_list()}).
+
+-type authz_ace() :: #authz_ace{}.
+-type authz_acl() :: [{access_method(), #authz_ace{}},...].
+
+-define(access_methods, [create, read, update, delete, grant]).
+
+-record(chef_container, {
+          'id',             % guid for object (unique)
+          'authz_id',       % authorization guid (unique)
+          'org_id',         % organization guid
+          'name',           % name of container
+          'path',           % 'path' of container (not used? Orig part of inheritance mech?; safe to delete? Yea!)
+          'last_updated_by' % authz guid of last actor to update object
+         }).
+
+-record(oc_chef_authz_context,
+        {reqid :: binary(),
+         otto_connection :: couchbeam:server(),
+         darklaunch :: term()}).
+
+-type oc_chef_authz_context() :: #oc_chef_authz_context{}.
+
+-type requestor_id() :: binary().
+-type actor_id() :: binary().
+-type object_id() :: <<_:256>>.
+-type db_key() :: binary() | string().
+
+-type authz_type() :: 'authz_client' |
+                      'authz_container' |
+                      'authz_cookbook' |
+                      'authz_data_bag' |
+                      'authz_environment' |
+                      'authz_group' |
+                      'authz_node' |
+                      'authz_role'.
+
+-type container_name() :: binary().
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% END VENDORED Records
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+

--- a/src/mv_oc_chef_authz_http.erl
+++ b/src/mv_oc_chef_authz_http.erl
@@ -1,0 +1,213 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
+%% ex: ts=4 sw=4 et
+%% @author Kevin Smith <kevin@opscode.com>
+%% @doc oc_chef_authz's interface to the authz server
+%%
+%% Copyright 2011-2013 Opscode, Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% VENDORED copy of oc_chef_authz_http, copied from oc_erchef at
+%% d0fa517e23483ca9555721a0ebae681e30f9d104 (tag 1.6.4).
+%%
+%% You should not need to modify this code in any breaking way unless there is
+%% a breaking change in the bifrost/authz HTTP API.
+%%
+%% If you are writing a migration that needs a future version of this code,
+%% re-vendor it as mv_oc_chef_authz_1 or similar.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+-module(mv_oc_chef_authz_http).
+
+-define(x_ops_requester_id, "X-Ops-Requesting-Actor-Id").
+-define(x_ops_user, {"X-Ops-User-Id", "front-end-service"}).
+-define(IBROWSE_OPTIONS, [{response_format, binary}]).
+-define(REQ_ID_HEADER, "X-Request-Id").
+
+-type http_body() :: binary() | [].
+-type requestor_id() :: binary().
+-type http_method() :: atom().
+-type http_path() :: string() | binary().
+-type http_headers() :: [{string(), string()}].
+-type req_id() :: string() | binary() | undefined.
+-type request_fun() :: fun((http_path(), http_method(), http_headers(), http_body()) -> {error, _} | ok | {ok, _}).
+-type new_client_fun() :: fun((request_fun()) -> any()).
+
+-export([ping/0,
+         request/5,
+         request/6,
+         request/7,
+         with_new_http_client/3,
+         with_new_http_client/5,
+         create_pool/0,
+         delete_pool/0
+     ]).
+
+-ifdef(TEST).
+-compile([export_all]).
+-endif.
+
+%
+% Handle raw interaction with authz; set up the headers as expected.
+%
+-spec request(http_path(),
+              http_method(),
+              [{string(), string()}],
+              http_body(),
+              requestor_id()) -> ok | {ok, _} | {error, _}.
+request(Path, Method, Headers, Body, RequestorId) ->
+    request(undefined, no_pid, Path, Method, Headers, Body, RequestorId).
+
+-spec request(req_id(),
+              http_path(),
+              http_method(),
+              [{string(), string()}],
+              http_body(),
+              requestor_id()) -> ok | {ok, _} | {error, _}.
+request(ReqId, Path, Method, Headers, Body, RequestorId) ->
+    request(ReqId, no_pid, Path, Method, Headers, Body, RequestorId).
+
+-spec request(req_id(), pid() | 'no_pid', http_path(), http_method(), [{string(),
+              string()}], http_body(), requestor_id()) -> ok | {ok, _} | {error, _}.
+              request(ReqId, _Pid, Path, Method, Headers, Body, RequestorId) ->
+    FullHeaders = full_headers(ReqId, RequestorId, Headers),
+    AuthzConfig = envy:get(oc_chef_authz, authz_service, list),
+    Timeout = proplists:get_value(timeout, AuthzConfig),
+    Response = oc_httpc:request(?MODULE, to_str(Path), FullHeaders, Method, Body, Timeout),
+    handle_ibrowse_response(Response).
+
+handle_ibrowse_response({ok, Status, _, ResponseBody}) when Status =:= "200";
+                                                            Status =:= "201" ->
+    handle_response_body(ResponseBody);
+handle_ibrowse_response({ok, "204", _H, _B}) ->
+    ok;
+handle_ibrowse_response({ok, "403", _H, _B}) ->
+    {error, forbidden};
+handle_ibrowse_response({ok, "404", _H, _B}) ->
+    {error, not_found};
+handle_ibrowse_response({ok, "500", _H, _B}) ->
+    {error, server_error};
+handle_ibrowse_response({ok, Status, _H, _B}) ->
+    {error, Status};
+handle_ibrowse_response({error, _} = Error) ->
+    Error.
+
+handle_response_body("{}") ->
+    ok;
+handle_response_body(<<"{}">>) ->
+    ok;
+handle_response_body(Body) ->
+    {ok, jiffy:decode(Body)}.
+
+full_headers(ReqId, RequestorId, Headers) ->
+    Headers1 = add_requestor_id_header(RequestorId, add_req_id_header(ReqId, Headers)),
+    [?x_ops_user,
+     {"Accept", "application/json"},
+     {"Content-Type", "application/json"} | Headers1].
+
+add_requestor_id_header(undefined, Headers) ->
+    Headers;
+add_requestor_id_header(RequestorId, Headers) ->
+    [{?x_ops_requester_id, to_str(RequestorId)} | Headers].
+
+add_req_id_header(undefined, Headers) ->
+    Headers;
+add_req_id_header(ReqId, Headers) ->
+    [{?REQ_ID_HEADER, to_str(ReqId)} | Headers].
+
+to_str(S) when is_list(S) ->
+    S;
+to_str(B) when is_binary(B) ->
+    binary_to_list(B).
+
+%% @doc Create a new HTTP connection to the authz service specified in config and execute
+%% `Fun'. See {@link with_new_http_client/3} for details.
+-spec with_new_http_client(req_id(), requestor_id(), new_client_fun()) -> any().
+with_new_http_client(ReqId, RequestorId, Fun) ->
+    {RootUrl, Timeout} = authz_url_and_timeout(),
+    with_new_http_client(ReqId, RequestorId, RootUrl, Timeout, Fun).
+
+%% Create a new HTTP connection (backed by `ibrowse_http_client') to the authz service at
+%% `RootUrl' and execute `Fun'. The function `Fun' will be passed three arguments: the `Pid'
+%% of the HTTP connection, `RootUrl', and `Timeout'. The HTTP connection will be closed and
+%% the result of `Fun' returned.
+-spec with_new_http_client(req_id(),
+                           requestor_id(),
+                           string(),
+                           non_neg_integer(),
+                           new_client_fun()) -> any().
+with_new_http_client(ReqId, RequestorId, _RootUrl, Timeout, Fun) ->
+    DecoratedFun = fun(RealRequestFun) ->
+                           DecoratedRequestFun = make_request_fun(ReqId, ignored, "", Timeout, RequestorId, RealRequestFun),
+                           Fun(DecoratedRequestFun)
+                           end,
+    oc_httpc:multi_request(?MODULE, DecoratedFun, Timeout).
+
+make_request_fun(ReqId, _Pid, _RawRootUrl, _Timeout, RequestorId, RealRequestFun) ->
+    fun(Path, Method, Headers, Body) ->
+            FullHeaders = full_headers(ReqId, RequestorId, Headers),
+            Resp = RealRequestFun(Path, FullHeaders, Method, Body),
+            handle_ibrowse_response(Resp)
+    end.
+
+
+-spec ping() -> pong | pang.
+ping() ->
+    {AuthzUrl, Timeout} = authz_url_and_timeout(),
+    ReqId = "ping-request",
+    RequestorId = <<"ping-requestor">>,
+    with_new_http_client(ReqId, RequestorId, AuthzUrl, Timeout, fun ping/1).
+
+ping(RequestFun) ->
+    try
+        Url = "/_ping",
+        Headers = [{"Accept", "application/json"}],
+        case RequestFun(Url, get, Headers, []) of
+            {ok, _} ->
+                pong;
+            ok ->
+                %% in case upstream status endpoint returns "{}"
+                pong;
+            {error, Reason} ->
+                error_logger:error_report({oc_chef_authz_http_ping, pang, Reason}),
+                pang
+        end
+    catch
+        _How:Error ->
+            error_logger:error_report({oc_chef_authz_http_ping, pang, Error}),
+            pang
+    end.
+
+authz_url_and_timeout() ->
+    Config = envy:get(oc_chef_authz, authz_service, list),
+    Url = proplists:get_value(root_url, Config),
+    Timeout = proplists:get_value(timeout, Config),
+    {Url, Timeout}.
+
+create_pool() ->
+    Pools = get_pool_configs(),
+    [oc_httpc:add_pool(PoolNameAtom, Config) || {PoolNameAtom, Config} <- Pools, Config /= []],
+    ok.
+
+delete_pool() ->
+    Pools = get_pool_configs(),
+    [ok = oc_httpc:delete_pool(PoolNameAtom) || {PoolNameAtom, _Config} <- Pools],
+    ok.
+
+get_pool_configs() ->
+    Config = envy:get(oc_chef_authz, authz_service, [], any),
+    [{?MODULE, Config}].


### PR DESCRIPTION
:construction: WIP -has a ton of debug garbage, etc :construction: 

First commit is the thing that comments out the CouchDB dep. Subsequent commits are my WIP for mover policy to add containers to existing orgs. Majority of the migration module is a vendored and somewhat modified copy of oc_chef_authz_org_creator, where I replaced anything calling chef_sql/db/object with direct sqerl calls. This gives us code that is coupled to the correct version of the database (at some point in the future, oc_erchef will be coupled to a future version of the database, which means it would no longer work for this migration).

Per our discussions, I'm going to vendor oc_chef_authz to remove that coupling as well. Note that since authz is hitting an HTTP API, a change to that API would break this migration but there's not really a good answer here since our other option is to be coupled to oc_chef_authz's code API.